### PR TITLE
ci: use RELEASE_PAT for release job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary
- Use `RELEASE_PAT` secret instead of `GITHUB_TOKEN` in release checkout so version bump commits can push to main past branch protection

## Setup
- Add repo secret `RELEASE_PAT` with a PAT that has `contents: write` scope