### PR TITLE
chore: dogfood `init` — add CI adoption files to the repo

### DIFF
--- a/.cursor/rules/codebase-intelligence.mdc
+++ b/.cursor/rules/codebase-intelligence.mdc
@@ -1,0 +1,29 @@
+---
+description: Codebase Intelligence — query the CLI before grep/read for architecture, impact, and risk
+alwaysApply: true
+---
+
+<!-- codebase-intelligence:start (auto-generated — do not edit between markers) -->
+## Codebase Intelligence
+
+This repo is analyzed by `codebase-intelligence` — a static-analysis tool that maps
+architecture, dependencies, and risk metrics for TypeScript code.
+
+**Use it BEFORE grep/read when you need to understand structure, impact, or risk.**
+It is faster and more accurate than reading files one at a time.
+
+| When you need to… | Run |
+|---|---|
+| Understand the codebase | `codebase-intelligence overview .` |
+| Find where complexity/risk lives | `codebase-intelligence hotspots .` |
+| Blast radius before editing a symbol | `codebase-intelligence impact . <symbol>` |
+| Who depends on a file | `codebase-intelligence dependents . <file>` |
+| Find unused exports | `codebase-intelligence dead-exports .` |
+| Keyword search | `codebase-intelligence search . <query>` |
+| Plan a rename | `codebase-intelligence rename . <old> <new>` |
+
+- Add `--json` for machine-readable output (use in automation/subagents).
+- No global install? Prefix with `npx codebase-intelligence@latest`.
+- Full command list: `codebase-intelligence --help`.
+- MCP stdio server: `codebase-intelligence .`
+<!-- codebase-intelligence:end -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+<!-- codebase-intelligence:start (auto-generated — do not edit between markers) -->
+## Codebase Intelligence
+
+This repo is analyzed by `codebase-intelligence` — a static-analysis tool that maps
+architecture, dependencies, and risk metrics for TypeScript code.
+
+**Use it BEFORE grep/read when you need to understand structure, impact, or risk.**
+It is faster and more accurate than reading files one at a time.
+
+| When you need to… | Run |
+|---|---|
+| Understand the codebase | `codebase-intelligence overview .` |
+| Find where complexity/risk lives | `codebase-intelligence hotspots .` |
+| Blast radius before editing a symbol | `codebase-intelligence impact . <symbol>` |
+| Who depends on a file | `codebase-intelligence dependents . <file>` |
+| Find unused exports | `codebase-intelligence dead-exports .` |
+| Keyword search | `codebase-intelligence search . <query>` |
+| Plan a rename | `codebase-intelligence rename . <old> <new>` |
+
+- Add `--json` for machine-readable output (use in automation/subagents).
+- No global install? Prefix with `npx codebase-intelligence@latest`.
+- Full command list: `codebase-intelligence --help`.
+- MCP stdio server: `codebase-intelligence .`
+<!-- codebase-intelligence:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,28 @@ src/
   community/index.ts  Louvain clustering
   persistence/index.ts Graph cache (.code-visualizer/)
 ```
+
+<!-- codebase-intelligence:start (auto-generated — do not edit between markers) -->
+## Codebase Intelligence
+
+This repo is analyzed by `codebase-intelligence` — a static-analysis tool that maps
+architecture, dependencies, and risk metrics for TypeScript code.
+
+**Use it BEFORE grep/read when you need to understand structure, impact, or risk.**
+It is faster and more accurate than reading files one at a time.
+
+| When you need to… | Run |
+|---|---|
+| Understand the codebase | `codebase-intelligence overview .` |
+| Find where complexity/risk lives | `codebase-intelligence hotspots .` |
+| Blast radius before editing a symbol | `codebase-intelligence impact . <symbol>` |
+| Who depends on a file | `codebase-intelligence dependents . <file>` |
+| Find unused exports | `codebase-intelligence dead-exports .` |
+| Keyword search | `codebase-intelligence search . <query>` |
+| Plan a rename | `codebase-intelligence rename . <old> <new>` |
+
+- Add `--json` for machine-readable output (use in automation/subagents).
+- No global install? Prefix with `npx codebase-intelligence@latest`.
+- Full command list: `codebase-intelligence --help`.
+- MCP stdio server: `codebase-intelligence .`
+<!-- codebase-intelligence:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,3 +186,28 @@ LLM knowledge base for building this tool. Single source of truth per topic:
 - NEVER create fake/stub graph objects — build them through the real pipeline
 - NEVER skip tests because "it's just config"
 - NEVER write tests that pass regardless of implementation (test behavior, not existence)
+
+<!-- codebase-intelligence:start (auto-generated — do not edit between markers) -->
+## Codebase Intelligence
+
+This repo is analyzed by `codebase-intelligence` — a static-analysis tool that maps
+architecture, dependencies, and risk metrics for TypeScript code.
+
+**Use it BEFORE grep/read when you need to understand structure, impact, or risk.**
+It is faster and more accurate than reading files one at a time.
+
+| When you need to… | Run |
+|---|---|
+| Understand the codebase | `codebase-intelligence overview .` |
+| Find where complexity/risk lives | `codebase-intelligence hotspots .` |
+| Blast radius before editing a symbol | `codebase-intelligence impact . <symbol>` |
+| Who depends on a file | `codebase-intelligence dependents . <file>` |
+| Find unused exports | `codebase-intelligence dead-exports .` |
+| Keyword search | `codebase-intelligence search . <query>` |
+| Plan a rename | `codebase-intelligence rename . <old> <new>` |
+
+- Add `--json` for machine-readable output (use in automation/subagents).
+- No global install? Prefix with `npx codebase-intelligence@latest`.
+- Full command list: `codebase-intelligence --help`.
+- MCP stdio server: `codebase-intelligence .`
+<!-- codebase-intelligence:end -->

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,24 @@
+<!-- codebase-intelligence:start (auto-generated — do not edit between markers) -->
+## Codebase Intelligence
+
+This repo is analyzed by `codebase-intelligence` — a static-analysis tool that maps
+architecture, dependencies, and risk metrics for TypeScript code.
+
+**Use it BEFORE grep/read when you need to understand structure, impact, or risk.**
+It is faster and more accurate than reading files one at a time.
+
+| When you need to… | Run |
+|---|---|
+| Understand the codebase | `codebase-intelligence overview .` |
+| Find where complexity/risk lives | `codebase-intelligence hotspots .` |
+| Blast radius before editing a symbol | `codebase-intelligence impact . <symbol>` |
+| Who depends on a file | `codebase-intelligence dependents . <file>` |
+| Find unused exports | `codebase-intelligence dead-exports .` |
+| Keyword search | `codebase-intelligence search . <query>` |
+| Plan a rename | `codebase-intelligence rename . <old> <new>` |
+
+- Add `--json` for machine-readable output (use in automation/subagents).
+- No global install? Prefix with `npx codebase-intelligence@latest`.
+- Full command list: `codebase-intelligence --help`.
+- MCP stdio server: `codebase-intelligence .`
+<!-- codebase-intelligence:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,24 @@
+<!-- codebase-intelligence:start (auto-generated — do not edit between markers) -->
+## Codebase Intelligence
+
+This repo is analyzed by `codebase-intelligence` — a static-analysis tool that maps
+architecture, dependencies, and risk metrics for TypeScript code.
+
+**Use it BEFORE grep/read when you need to understand structure, impact, or risk.**
+It is faster and more accurate than reading files one at a time.
+
+| When you need to… | Run |
+|---|---|
+| Understand the codebase | `codebase-intelligence overview .` |
+| Find where complexity/risk lives | `codebase-intelligence hotspots .` |
+| Blast radius before editing a symbol | `codebase-intelligence impact . <symbol>` |
+| Who depends on a file | `codebase-intelligence dependents . <file>` |
+| Find unused exports | `codebase-intelligence dead-exports .` |
+| Keyword search | `codebase-intelligence search . <query>` |
+| Plan a rename | `codebase-intelligence rename . <old> <new>` |
+
+- Add `--json` for machine-readable output (use in automation/subagents).
+- No global install? Prefix with `npx codebase-intelligence@latest`.
+- Full command list: `codebase-intelligence --help`.
+- MCP stdio server: `codebase-intelligence .`
+<!-- codebase-intelligence:end -->


### PR DESCRIPTION
Dogfoods the `init` command shipped in #34, verified against the published canary `2.3.0-canary.8cfac95`.

Running `codebase-intelligence@canary init .` on this repo generated the agent-adoption files. The repo now practices what it ships — AI agents working here are told to query codebase-intelligence before grep/read.

## Files
- `AGENTS.md`, `CLAUDE.md` — managed instruction block appended (existing content untouched)
- `GEMINI.md`, `CONVENTIONS.md`, `.cursor/rules/codebase-intelligence.mdc`, `.github/copilot-instructions.md` — new

Pure additions (151 insertions, 0 deletions). Docs/agent files only — no `src/**` change, so this does **not** trigger a canary publish on merge.

## Verification
`init` from the published canary: 6 files written, pre-existing content preserved, re-run fully idempotent, skill install confirmed (temp HOME). End-to-end pipeline (merge → OIDC canary publish → npx @canary → init) works.