### PR TITLE
chore(release): bump to v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-06-01
+
 ### Added
 
 - **`init` command** — agent adoption layer. `codebase-intelligence init [path]` writes
@@ -38,5 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Baseline for this changelog. For release history prior to and including 2.3.0, see the
 [git tags](https://github.com/bntvllnt/codebase-intelligence/tags) and commit history.
 
-[Unreleased]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/bntvllnt/codebase-intelligence/releases/tag/v2.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-intelligence",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Codebase analysis engine with MCP integration for LLM-assisted code understanding",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
Release prep for **2.4.0**.

## Changes
- `package.json`: `2.3.0` → `2.4.0` (minor — new `init` command).
- `CHANGELOG.md`: `[Unreleased]` → `[2.4.0] - 2026-06-01`, fresh empty `[Unreleased]`, compare links updated.

## What ships in 2.4.0
- `init` command — agent adoption layer (#34)
- Opt-in agent selection + interactive picker (#36)

## After merge
Dispatch the **Publish** workflow (workflow_dispatch on main) → tags `v2.4.0`, `npm publish --tag latest` via OIDC, creates the GitHub Release.