### PR TITLE
fix(cli): harden 2.5 canary validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0-canary] - 2026-06-30
+
+> Canary base for 2.5.0. Merging to `main` publishes `2.5.0-canary.<sha>` with
+> the npm `canary` tag; no stable 2.5.0 release has been cut.
+
+### Changed
+
+- **Base package version moved to `2.5.0` for canary publishing.** The publish
+  workflow derives canaries from `package.json`, so this produces
+  `2.5.0-canary.<sha>` artifacts while release creation remains manual.
+- **CLI docs now include the full 17-command surface.** `check` is documented
+  alongside the 15 analysis commands and `init`, matching `--help`.
+
+### Fixed
+
+- **`changes <target>` now analyzes the target repo, not the caller's cwd.** Git
+  diff commands run in the requested root with relative paths, so cross-repo
+  reviews no longer report the wrong files.
+- **`file` accepts paths returned by other commands.** Exact graph paths like
+  `src/...` or `app/...` are tried before common-prefix stripping.
+- **Subcommand `--force` now consistently bypasses cache.** Analysis commands
+  honor command-local and global `--force` flags.
+- **Monorepo package parsing honors parent `.gitignore` files.** Generated
+  directories such as `.next/` are excluded when the target path is a package
+  below the repo root.
+- **Invalid enum-like CLI options fail with exit code 2.** Unknown
+  `hotspots --metric`, `changes --scope`, and `check --gate` values now return a
+  clear usage error instead of silently producing misleading output.
+- **`pnpm test` now rebuilds before running dist-backed CLI E2E tests.** This
+  prevents stale `dist/cli.js` from masking source changes without parallel
+  rebuild churn, and runs Vitest with forked non-parallel file execution to avoid
+  worker progress RPC timeouts on the heavy real-codebase suites.
+
 ## [2.4.1] - 2026-06-01
 
 ### Fixed
@@ -59,6 +92,7 @@ Baseline for this changelog. For release history prior to and including 2.3.0, s
 [git tags](https://github.com/bntvllnt/codebase-intelligence/tags) and commit history.
 
 [Unreleased]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.4.1...HEAD
+[2.5.0-canary]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.4.1...HEAD
 [2.4.1]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/bntvllnt/codebase-intelligence/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/bntvllnt/codebase-intelligence/releases/tag/v2.3.0

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 
 ## Features
 
-- **16 CLI commands** for architecture analysis, dependency impact, dead code detection, search, and agent setup
+- **17 CLI commands** for architecture analysis, dependency impact, dead code detection, search, CI rules, and agent setup
 - **Machine-readable JSON output** (`--json`) for automation and CI pipelines
 - **Auto-cached index** in `.code-visualizer/` for fast repeat queries
 - **11 architectural metrics** — PageRank, betweenness, coupling, cohesion, tension, churn, complexity, blast radius, dead exports, test coverage, escape velocity
@@ -64,7 +64,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 - **Process tracing** — detect entry points and execution flows through the call graph
 - **Community detection** — Louvain clustering for natural file groupings
 - **Agent adoption** — `init` writes per-agent instruction files + installs a skill so AI agents query CI before grep/read
-- **MCP parity (secondary)** — same analysis available as 15 MCP tools, 2 prompts, and 3 resources
+- **MCP parity (secondary)** — same analysis and rules gate available as 16 MCP tools, 2 prompts, and 3 resources
 
 ## Installation
 
@@ -106,6 +106,7 @@ codebase-intelligence <command> <path> [options]
 | `rename` | Reference discovery for rename planning |
 | `processes` | Entry-point execution flow tracing |
 | `clusters` | Community-detected file clusters |
+| `check` | Rules-engine gate for CI |
 | `init` | Set up AI agents to use CI — writes per-agent instruction files (skill opt-in via `--skill`) |
 
 ### Useful flags
@@ -116,6 +117,7 @@ codebase-intelligence <command> <path> [options]
 | `--force` | Rebuild index even if cache is valid |
 | `--limit <n>` | Limit results on supported commands |
 | `--metric <m>` | Select ranking metric for `hotspots` |
+| `--scope <s>` | Select git diff scope for `changes`: `staged`, `unstaged`, `all` |
 
 For full command details, see [docs/cli-reference.md](docs/cli-reference.md).
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-16 commands for terminal and CI use. The 15 analysis commands have full parity with MCP tools and auto-cache the index to `.code-visualizer/`; `init` sets up agent adoption.
+17 commands for terminal and CI use. The 15 analysis commands have full parity with MCP tools and auto-cache the index to `.code-visualizer/`; `check` runs the rules gate; `init` sets up agent adoption.
 
 ## Commands
 
@@ -156,6 +156,22 @@ codebase-intelligence clusters <path> [--min-files <n>] [--json] [--force]
 
 **Output:** clusters with files, file count, cohesion.
 
+### check
+
+Rules-engine gate for CI.
+
+```bash
+codebase-intelligence check <path> [--config <path>] [--format <fmt>] [--fail-on <severity>] [--gate <mode>] [--base <ref>] [--quiet] [--summary] [--json] [--force]
+```
+
+**Formats:** `text` (default), `json`, `sarif`.
+
+**Fail-on:** `error` (default), `warn`, `never`.
+
+**Gate modes:** `all` (default), `new-only`.
+
+**Output:** pass/warn/fail verdict, findings, and summary counts. Exit code `0` on pass, `1` when the configured gate fails, `2` for invalid config or arguments.
+
 ### init
 
 Set up AI agents to use codebase-intelligence by writing a managed instruction block
@@ -192,6 +208,12 @@ codebase-intelligence init [path] [--agents <list>] [--all] [--skill] [--yes] [-
 | `--entry <name>` | processes | Filter by entry point name |
 | `--min-files <n>` | clusters | Min files per cluster |
 | `--no-dry-run` | rename | Actually perform the rename (default: dry run) |
+| `--format <fmt>` | check | Output format: text, json, sarif |
+| `--fail-on <severity>` | check | Severity that fails the gate: error, warn, never |
+| `--gate <mode>` | check | Gate mode: all, new-only |
+| `--base <ref>` | check | Base git ref for new-only gating |
+| `--quiet` | check | Suppress output when the result passes |
+| `--summary` | check | Print summary counts only |
 | `--agents <list>` | init | Comma-separated agents, non-interactive (default: agents,claude) |
 | `--all` | init | Target every agent (non-interactive) |
 | `--skill` | init | Also install the global Claude skill (opt-in) |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -19,7 +19,7 @@ Detailed context for a single file.
 **Input:** `{ filePath: string }` (relative path)
 **Returns:** path, loc, exports, imports (with symbols, isTypeOnly, weight), dependents (with symbols, isTypeOnly, weight), metrics (all FileMetrics including churn, complexity, blastRadius, deadExports, hasTests, testFile)
 
-**Path normalization:** Backslashes are normalized to forward slashes. Common prefixes (`src/`, `lib/`, `app/`) are stripped once from the leading position before graph lookup. If the file is not found, the error includes up to 3 suggested similar paths.
+**Path normalization:** Backslashes are normalized to forward slashes. The exact graph path is tried first; if not found, common prefixes (`src/`, `lib/`, `app/`) are stripped once from the leading position and retried. If the file is not found, the error includes up to 3 suggested similar paths.
 
 **Use when:** Before modifying a file, understand its role, connections, and risk profile.
 **Not for:** Symbol-level detail (use symbol_context).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,8 +25,8 @@ Analyzer
   | produces: ForceAnalysis (tension files, bridges, extraction candidates)
   v
 MCP (stdio) + CLI
-  | MCP: 15 tools, 2 prompts, 3 resources for LLM agents
-  | CLI: 5 commands with formatted + JSON output for humans/CI
+  | MCP: 16 tools, 2 prompts, 3 resources for LLM agents
+  | CLI: 17 commands with formatted + JSON output for humans/CI
 ```
 
 ## Module Map
@@ -38,7 +38,7 @@ src/
   graph/index.ts       <- graphology graph + circular dep detection
   analyzer/index.ts    <- All metric computation
   core/index.ts        <- Shared result computation (MCP + CLI)
-  mcp/index.ts         <- 15 MCP tools for LLM integration
+  mcp/index.ts         <- 16 MCP tools for LLM integration
   mcp/hints.ts         <- Next-step hints for MCP tool responses
   impact/index.ts      <- Symbol-level impact analysis + rename planning
   search/index.ts      <- BM25 search engine
@@ -212,7 +212,7 @@ The most dangerous files have: high churn + high coupling + low coverage.
 
 # MCP Tools Reference
 
-15 tools available via MCP stdio.
+16 tools available via MCP stdio.
 
 ## 1. codebase_overview
 High-level summary. Input: `{ depth?: number }`. Returns: totalFiles, totalFunctions, modules, topDependedFiles, metrics.
@@ -283,7 +283,7 @@ Community-detected file clusters. Input: `{ minFiles?: number }`. Returns: clust
 
 # CLI Reference
 
-16 commands — 15 analysis commands (full parity with MCP tools) plus `init` for agent adoption.
+17 commands — 15 analysis commands (full parity with MCP tools), `check` for CI rules, and `init` for agent adoption.
 
 ## Commands
 
@@ -390,6 +390,13 @@ shows an interactive picker (`AGENTS.md` + `CLAUDE.md` preselected); non-interac
 targets every agent, `--skill` also installs the portable skill to
 `~/.claude/skills/codebase-intelligence/SKILL.md` (never installed otherwise). Only
 content between the `codebase-intelligence:start`/`:end` markers is ever touched.
+
+### check
+```bash
+codebase-intelligence check <path> [--config <path>] [--format <fmt>] [--fail-on <severity>] [--gate <mode>] [--base <ref>] [--quiet] [--summary] [--json] [--force]
+```
+Rules-engine gate for CI. Formats: text, json, sarif. Fail-on: error, warn, never.
+Gate modes: all, new-only. Returns pass/warn/fail verdict, findings, and summary counts.
 
 ## Global Behavior
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 - [Architecture](docs/architecture.md): Pipeline, module map, data flow, design decisions
 - [Data Model](docs/data-model.md): All TypeScript interfaces with field descriptions
 - [Metrics](docs/metrics.md): Per-file and module metrics, force analysis, complexity scoring
-- [MCP Tools](docs/mcp-tools.md): 15 MCP tools — inputs, outputs, use cases, selection guide
+- [MCP Tools](docs/mcp-tools.md): 16 MCP tools — inputs, outputs, use cases, selection guide
 - [CLI Reference](docs/cli-reference.md): CLI commands, flags, output formats, examples
 
 ## Quick Start
@@ -17,7 +17,7 @@ MCP mode (AI agents):
 codebase-intelligence ./path/to/project
 ```
 
-CLI mode (humans/CI) — 16 commands (15 analysis with MCP parity + `init` for agent adoption):
+CLI mode (humans/CI) — 17 commands (15 analysis with MCP parity + `check` + `init`):
 ```bash
 codebase-intelligence overview ./src
 codebase-intelligence hotspots ./src --metric coupling
@@ -34,6 +34,7 @@ codebase-intelligence impact ./src getUserById
 codebase-intelligence rename ./src oldName newName
 codebase-intelligence processes ./src --entry main
 codebase-intelligence clusters ./src --min-files 3
+codebase-intelligence check ./src                      # rules gate for CI
 codebase-intelligence init .                         # make AI agents use CI
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-intelligence",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Codebase analysis engine with MCP integration for LLM-assisted code understanding",
   "type": "module",
   "main": "dist/cli.js",
@@ -12,7 +12,7 @@
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsx src/cli.ts",
     "start": "node dist/cli.js",
-    "test": "vitest run",
+    "test": "pnpm build && vitest run --pool forks --no-file-parallelism",
     "test:watch": "vitest",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,8 +27,12 @@ import {
   computeOverview,
   computeFileContext,
   computeHotspots,
+  HOTSPOT_METRICS,
+  isHotspotMetric,
   computeSearch,
   computeChanges,
+  CHANGE_SCOPES,
+  isChangeScope,
   computeDependents,
   computeModuleStructure,
   computeForces,
@@ -201,6 +205,10 @@ interface InitOptions {
 
 const program = new Command();
 
+function forceOption(options: CliCommandOptions): boolean {
+  return options.force === true || program.opts<{ force?: boolean }>().force === true;
+}
+
 program
   .name("codebase-intelligence")
   .description("Analyze TypeScript codebases — architecture, dependencies, metrics.")
@@ -225,7 +233,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: CliCommandOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = computeOverview(graph);
 
     if (options.json) {
@@ -268,13 +276,17 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: HotspotOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
     const metric = options.metric ?? "coupling";
+    if (!isHotspotMetric(metric)) {
+      process.stderr.write(`Error: --metric must be one of: ${HOTSPOT_METRICS.join(", ")}\n`);
+      process.exit(2);
+    }
     const limit = options.limit ? parseInt(options.limit, 10) : 10;
     if (isNaN(limit) || limit < 1) {
       process.stderr.write("Error: --limit must be a positive integer\n");
       process.exit(2);
     }
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = computeHotspots(graph, metric, limit);
 
     if (options.json) {
@@ -307,7 +319,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, filePath: string, options: CliCommandOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = computeFileContext(graph, filePath);
 
     if ("error" in result) {
@@ -386,7 +398,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, query: string, options: SearchOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const limit = options.limit ? parseInt(options.limit, 10) : 20;
     if (isNaN(limit) || limit < 1) {
       process.stderr.write("Error: --limit must be a positive integer\n");
@@ -427,8 +439,15 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: ChangesOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
-    const result = computeChanges(graph, options.scope);
+    const scope = options.scope;
+    if (scope !== undefined) {
+      if (!isChangeScope(scope)) {
+        process.stderr.write(`Error: --scope must be one of: ${CHANGE_SCOPES.join(", ")}\n`);
+        process.exit(2);
+      }
+    }
+    const { graph } = loadGraph(targetPath, forceOption(options));
+    const result = computeChanges(graph, scope, path.resolve(targetPath));
 
     if ("error" in result) {
       process.stderr.write(`Error: ${result.error}\n`);
@@ -493,7 +512,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, filePath: string, options: DependentsOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const depth = options.depth ? parseInt(options.depth, 10) : undefined;
     if (depth !== undefined && (isNaN(depth) || depth < 1)) {
       process.stderr.write("Error: --depth must be a positive integer\n");
@@ -542,7 +561,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: CliCommandOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = computeModuleStructure(graph);
 
     if (options.json) {
@@ -589,7 +608,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: ForcesOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const cohesion = options.cohesion ? parseFloat(options.cohesion) : undefined;
     const tension = options.tension ? parseFloat(options.tension) : undefined;
     const escape = options.escape ? parseFloat(options.escape) : undefined;
@@ -686,7 +705,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: DeadExportsOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const limit = options.limit ? parseInt(options.limit, 10) : undefined;
     if (limit !== undefined && (isNaN(limit) || limit < 1)) {
       process.stderr.write("Error: --limit must be a positive integer\n");
@@ -723,7 +742,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: CliCommandOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = computeGroups(graph);
 
     if (options.json) {
@@ -752,7 +771,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, symbolName: string, options: CliCommandOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = computeSymbolContext(graph, symbolName);
 
     if ("error" in result) {
@@ -804,7 +823,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, symbol: string, options: CliCommandOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const result = impactAnalysis(graph, symbol);
 
     if (result.notFound) {
@@ -844,7 +863,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, oldName: string, newName: string, options: RenameOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const dryRun = options.dryRun !== false;
     const result = renameSymbol(graph, oldName, newName, dryRun);
 
@@ -878,7 +897,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: ProcessesOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const limit = options.limit ? parseInt(options.limit, 10) : undefined;
     if (limit !== undefined && (isNaN(limit) || limit < 1)) {
       process.stderr.write("Error: --limit must be a positive integer\n");
@@ -919,7 +938,7 @@ program
   .option("--json", "Output as JSON")
   .option("--force", "Re-index even if HEAD unchanged")
   .action((targetPath: string, options: ClustersOptions) => {
-    const { graph } = loadGraph(targetPath, options.force);
+    const { graph } = loadGraph(targetPath, forceOption(options));
     const minFiles = options.minFiles ? parseInt(options.minFiles, 10) : undefined;
     if (minFiles !== undefined && (isNaN(minFiles) || minFiles < 1)) {
       process.stderr.write("Error: --min-files must be a positive integer\n");
@@ -1043,8 +1062,10 @@ function parseFailOn(value: string | undefined): "error" | "warn" | "never" | un
   return false;
 }
 
-function parseGate(value: string | undefined): "all" | "new-only" | undefined {
-  return value === "all" || value === "new-only" ? value : undefined;
+function parseGate(value: string | undefined): "all" | "new-only" | undefined | false {
+  if (value === undefined) return undefined;
+  if (value === "all" || value === "new-only") return value;
+  return false;
 }
 
 program
@@ -1073,13 +1094,19 @@ program
       process.exit(2);
     }
 
+    const gate = parseGate(options.gate);
+    if (gate === false) {
+      process.stderr.write("Error: --gate must be one of: all, new-only\n");
+      process.exit(2);
+    }
+
     try {
-      const { graph } = loadGraph(targetPath, options.force);
+      const { graph } = loadGraph(targetPath, forceOption(options));
       const result = runCheck(graph, path.resolve(targetPath), {
         configPath: options.config,
         format,
         failOn,
-        gate: parseGate(options.gate),
+        gate,
         base: options.base,
         quiet: options.quiet,
         summary: options.summary,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import path from "node:path";
 import type { CodebaseGraph } from "../types/index.js";
 import { createSearchIndex, search, getSuggestions } from "../search/index.js";
 import type { SearchIndex } from "../search/index.js";
@@ -7,13 +8,17 @@ import { impactAnalysis, renameSymbol } from "../impact/index.js";
 // ── Path helpers ────────────────────────────────────────────
 
 export function normalizeFilePath(filePath: string): string {
-  let normalized = filePath.replace(/\\/g, "/");
-  normalized = normalized.replace(/^(src|lib|app)\//, "");
-  return normalized;
+  return filePath.replace(/\\/g, "/");
+}
+
+function stripCommonFilePrefix(normalizedPath: string): string {
+  return normalizedPath.replace(/^(src|lib|app)\//, "");
 }
 
 export function resolveFilePath(normalizedPath: string, graph: CodebaseGraph): string | undefined {
   if (graph.fileMetrics.has(normalizedPath)) return normalizedPath;
+  const stripped = stripCommonFilePrefix(normalizedPath);
+  if (stripped !== normalizedPath && graph.fileMetrics.has(stripped)) return stripped;
   return undefined;
 }
 
@@ -161,12 +166,13 @@ export function computeFileContext(
   const normalizedPath = normalizeFilePath(rawFilePath);
   const filePath = resolveFilePath(normalizedPath, graph);
   if (!filePath) {
-    return { error: `File not found in graph: ${normalizedPath}`, suggestions: suggestSimilarPaths(normalizedPath, graph) };
+    const lookupPath = stripCommonFilePrefix(normalizedPath);
+    return { error: `File not found in graph: ${lookupPath}`, suggestions: suggestSimilarPaths(lookupPath, graph) };
   }
 
   const metrics = graph.fileMetrics.get(filePath);
   if (!metrics) {
-    return { error: `File not found in graph: ${normalizedPath}`, suggestions: suggestSimilarPaths(normalizedPath, graph) };
+    return { error: `File not found in graph: ${filePath}`, suggestions: suggestSimilarPaths(filePath, graph) };
   }
 
   const nodeById = buildNodeById(graph);
@@ -217,6 +223,28 @@ export interface HotspotsResult {
   metric: string;
   hotspots: HotspotEntry[];
   summary: string;
+}
+
+export const HOTSPOT_METRICS = [
+  "coupling",
+  "pagerank",
+  "fan_in",
+  "fan_out",
+  "betweenness",
+  "tension",
+  "escape_velocity",
+  "churn",
+  "complexity",
+  "blast_radius",
+  "coverage",
+] as const;
+
+export type HotspotMetric = typeof HOTSPOT_METRICS[number];
+
+const HOTSPOT_METRIC_SET: ReadonlySet<string> = new Set(HOTSPOT_METRICS);
+
+export function isHotspotMetric(metric: string): metric is HotspotMetric {
+  return HOTSPOT_METRIC_SET.has(metric);
 }
 
 export function computeHotspots(
@@ -352,20 +380,31 @@ export interface ChangesResult {
 
 export type ChangesError = { error: string; scope: string };
 
+export const CHANGE_SCOPES = ["staged", "unstaged", "all"] as const;
+
+export type ChangeScope = typeof CHANGE_SCOPES[number];
+
+const CHANGE_SCOPE_SET: ReadonlySet<string> = new Set(CHANGE_SCOPES);
+
+export function isChangeScope(scope: string): scope is ChangeScope {
+  return CHANGE_SCOPE_SET.has(scope);
+}
+
 export function computeChanges(
   graph: CodebaseGraph,
   scope?: string,
+  rootDir = process.cwd(),
 ): ChangesResult | ChangesError {
   const diffScope = scope ?? "all";
   try {
     let diffCmd: string;
     switch (diffScope) {
-      case "staged": diffCmd = "git diff --cached --name-only"; break;
-      case "unstaged": diffCmd = "git diff --name-only"; break;
-      default: diffCmd = "git diff HEAD --name-only"; break;
+      case "staged": diffCmd = "git diff --relative --cached --name-only"; break;
+      case "unstaged": diffCmd = "git diff --relative --name-only"; break;
+      default: diffCmd = "git diff --relative HEAD --name-only"; break;
     }
 
-    const output = execSync(diffCmd, { encoding: "utf-8", timeout: 5000 }).trim();
+    const output = execSync(diffCmd, { cwd: path.resolve(rootDir), encoding: "utf-8", timeout: 5000 }).trim();
     const changedFiles = output ? output.split("\n").filter((f) => f.length > 0) : [];
 
     const changedSymbols: Array<{ file: string; symbols: string[] }> = [];

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -218,7 +218,7 @@ export function registerTools(server: McpServer, graph: CodebaseGraph): void {
       scope: z.enum(["staged", "unstaged", "all"]).optional().describe("Git diff scope (default: all)"),
     },
     async ({ scope }) => {
-      const result = computeChanges(graph, scope);
+      const result = computeChanges(graph, scope, getRoot());
       if ("error" in result) {
         return {
           content: [{

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -92,7 +92,7 @@ export class Calculator {
       fs.rmSync(projectDir, { recursive: true, force: true });
     });
 
-    it("parses all TypeScript files", { timeout: 30_000 }, () => {
+    it("parses all TypeScript files", { timeout: 60_000 }, () => {
       const files = parseCodebase(projectDir);
       expect(files).toHaveLength(4);
     });
@@ -410,6 +410,25 @@ export const bar = foo;
         expect(relPaths).toEqual(["index.ts", "src/app.ts"]);
       } finally {
         fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it("honors parent .gitignore when parsing a package subdirectory", () => {
+      const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebase-viz-parent-ignore-"));
+      try {
+        fs.mkdirSync(path.join(repoDir, ".git"));
+        fs.writeFileSync(path.join(repoDir, ".gitignore"), ".next/\n");
+        const appDir = path.join(repoDir, "apps", "web");
+        fs.mkdirSync(path.join(appDir, ".next", "types"), { recursive: true });
+        fs.writeFileSync(path.join(appDir, "index.ts"), `export const app = 1;\n`);
+        fs.writeFileSync(path.join(appDir, ".next", "types", "generated.ts"), `export const generated = 1;\n`);
+
+        const files = parseCodebase(appDir);
+        const relPaths = files.map((f) => f.relativePath).sort();
+
+        expect(relPaths).toEqual(["index.ts"]);
+      } finally {
+        fs.rmSync(repoDir, { recursive: true, force: true });
       }
     });
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -86,13 +86,28 @@ export function parseCodebase(rootDir: string): ParsedFile[] {
 }
 
 function loadGitignorePatterns(rootDir: string): string[] {
-  const gitignorePath = path.join(rootDir, ".gitignore");
-  if (!fs.existsSync(gitignorePath)) return [];
-  const content = fs.readFileSync(gitignorePath, "utf-8");
-  return content
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith("#"));
+  const patterns: string[] = [];
+  let current = path.resolve(rootDir);
+
+  for (;;) {
+    const gitignorePath = path.join(current, ".gitignore");
+    if (fs.existsSync(gitignorePath)) {
+      const content = fs.readFileSync(gitignorePath, "utf-8");
+      patterns.push(
+        ...content
+          .split("\n")
+          .map((line) => line.trim())
+          .filter((line) => line && !line.startsWith("#")),
+      );
+    }
+
+    if (fs.existsSync(path.join(current, ".git"))) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return patterns;
 }
 
 function isGitignored(relativePath: string, patterns: string[]): boolean {

--- a/tests/cli-check.e2e.test.ts
+++ b/tests/cli-check.e2e.test.ts
@@ -77,7 +77,7 @@ const DEAD = {
 };
 
 beforeAll(() => {
-  if (!fs.existsSync(cli)) execSync("npm run build", { cwd: repoRoot, stdio: "inherit" });
+  if (!fs.existsSync(cli)) execSync("pnpm build", { cwd: repoRoot, stdio: "inherit" });
 }, 120_000);
 
 describe("check command (e2e)", () => {
@@ -161,6 +161,13 @@ describe("check command (e2e)", () => {
     const { status, stderr } = await run(["check", dir, "--format", "xml"]);
     expect(status).toBe(2);
     expect(stderr).toContain("--format must be one of");
+  });
+
+  it("exits 2 on an invalid --gate value", async () => {
+    const dir = makeProject(CLEAN, { rules: {} });
+    const { status, stderr } = await run(["check", dir, "--gate", "future-only"]);
+    expect(status).toBe(2);
+    expect(stderr).toContain("--gate must be one of");
   });
 
   it("--quiet wins over --summary on pass: no output, exit 0 (pinned contract)", async () => {

--- a/tests/cli-commands.test.ts
+++ b/tests/cli-commands.test.ts
@@ -1,10 +1,14 @@
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, it, expect } from "vitest";
 import { getFixturePipeline, getFixtureSrcPath } from "./helpers/pipeline.js";
 import {
   computeOverview,
   computeFileContext,
   computeHotspots,
+  HOTSPOT_METRICS,
   computeSearch,
   computeChanges,
   computeDependents,
@@ -120,21 +124,8 @@ describe("CLI core commands (integration)", () => {
 
     it("supports all valid metrics", () => {
       const { codebaseGraph } = getFixturePipeline();
-      const metrics = [
-        "coupling",
-        "pagerank",
-        "fan_in",
-        "fan_out",
-        "betweenness",
-        "tension",
-        "churn",
-        "complexity",
-        "blast_radius",
-        "coverage",
-        "escape_velocity",
-      ];
 
-      for (const metric of metrics) {
+      for (const metric of HOTSPOT_METRICS) {
         const result = computeHotspots(codebaseGraph, metric, 3);
         expect(result.metric).toBe(metric);
         expect(result.hotspots).toBeDefined();
@@ -209,6 +200,33 @@ describe("CLI core commands (integration)", () => {
       expect("error" in result).toBe(false);
     });
 
+    it("keeps src-prefixed paths when they exist in the graph", () => {
+      const { codebaseGraph } = getFixturePipeline();
+      const knownFile = [...codebaseGraph.fileMetrics.keys()][0];
+      const prefixedFile = `src/${knownFile}`;
+      const graph = {
+        ...codebaseGraph,
+        fileMetrics: new Map(
+          [...codebaseGraph.fileMetrics.entries()].map(([file, metrics]) => [
+            file === knownFile ? prefixedFile : file,
+            metrics,
+          ]),
+        ),
+        nodes: codebaseGraph.nodes.map((node) => {
+          if (node.id === knownFile) return { ...node, id: prefixedFile, path: prefixedFile };
+          if (node.parentFile === knownFile) return { ...node, parentFile: prefixedFile };
+          return node;
+        }),
+      };
+
+      const result = computeFileContext(graph, prefixedFile);
+
+      expect("error" in result).toBe(false);
+      if (!("error" in result)) {
+        expect(result.path).toBe(prefixedFile);
+      }
+    });
+
     it("JSON output is valid for success result", () => {
       const { codebaseGraph } = getFixturePipeline();
       const knownFile = [...codebaseGraph.fileMetrics.keys()][0];
@@ -280,6 +298,23 @@ describe("CLI core commands (integration)", () => {
   });
 
   describe("computeChanges", () => {
+    const GIT_ENV = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@example.com",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@example.com",
+    };
+
+    function git(dir: string, args: string[]): string {
+      return execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+        cwd: dir,
+        encoding: "utf-8",
+        env: GIT_ENV,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    }
+
     it("returns changes result with scope", () => {
       const { codebaseGraph } = getFixturePipeline();
       const result = computeChanges(codebaseGraph);
@@ -311,6 +346,30 @@ describe("CLI core commands (integration)", () => {
       const parsed = JSON.parse(json) as Record<string, unknown>;
 
       expect(parsed).toHaveProperty("scope");
+    });
+
+    it("runs git diff in the requested target root", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-changes-target-"));
+      try {
+        fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+        fs.writeFileSync(path.join(dir, "src", "target.ts"), "export const target = 1;\n");
+        git(dir, ["init"]);
+        git(dir, ["config", "user.email", "t@example.com"]);
+        git(dir, ["config", "user.name", "t"]);
+        git(dir, ["add", "-A"]);
+        git(dir, ["commit", "-m", "base", "--no-gpg-sign"]);
+        fs.writeFileSync(path.join(dir, "src", "target.ts"), "export const target = 2;\n");
+
+        const { codebaseGraph } = getFixturePipeline();
+        const result = computeChanges(codebaseGraph, "all", dir);
+
+        expect("error" in result).toBe(false);
+        if (!("error" in result)) {
+          expect(result.changedFiles).toEqual(["src/target.ts"]);
+        }
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -423,6 +482,59 @@ describe("CLI core commands (integration)", () => {
       for (const item of result.deepModules) expect(item.evidence.length).toBeGreaterThan(0);
       for (const item of result.seamCandidates) expect(item.evidence.length).toBeGreaterThan(0);
       for (const item of result.localityRisks) expect(item.evidence.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("overview CLI command", () => {
+    it("--force reparses even when a matching cache exists", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-force-cache-"));
+      try {
+        fs.writeFileSync(path.join(dir, "index.ts"), "export const value = 1;\n");
+        const first = spawnSync(
+          "pnpm",
+          ["exec", "tsx", "src/cli.ts", "overview", dir, "--json"],
+          { cwd: process.cwd(), encoding: "utf-8" },
+        );
+        expect(first.status).toBe(0);
+
+        const forced = spawnSync(
+          "pnpm",
+          ["exec", "tsx", "src/cli.ts", "overview", dir, "--json", "--force"],
+          { cwd: process.cwd(), encoding: "utf-8" },
+        );
+
+        expect(forced.status).toBe(0);
+        expect(forced.stderr).toContain("Parsing");
+        expect(forced.stderr).not.toContain("Using cached index");
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("CLI option validation", () => {
+    it("rejects unknown hotspot metrics before indexing", () => {
+      const result = spawnSync(
+        "pnpm",
+        ["exec", "tsx", "src/cli.ts", "hotspots", getFixtureSrcPath(), "--metric", "nope", "--json"],
+        { cwd: process.cwd(), encoding: "utf-8" },
+      );
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("Error: --metric must be one of:");
+      expect(result.stderr).not.toContain("Parsing");
+    });
+
+    it("rejects unknown changes scopes before indexing", () => {
+      const result = spawnSync(
+        "pnpm",
+        ["exec", "tsx", "src/cli.ts", "changes", getFixtureSrcPath(), "--scope", "nope", "--json"],
+        { cwd: process.cwd(), encoding: "utf-8" },
+      );
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("Error: --scope must be one of:");
+      expect(result.stderr).not.toContain("Parsing");
     });
   });
 

--- a/tests/cli-init.e2e.test.ts
+++ b/tests/cli-init.e2e.test.ts
@@ -33,11 +33,7 @@ function run(args: readonly string[], home: string): RunResult {
 }
 
 beforeAll(() => {
-  // E2E asserts against dist/ — the build gate runs before the test gate, but
-  // build here too if the artifact is missing so the suite is self-contained.
-  if (!fs.existsSync(cli)) {
-    execSync("npm run build", { cwd: repoRoot, stdio: "inherit" });
-  }
+  if (!fs.existsSync(cli)) execSync("pnpm build", { cwd: repoRoot, stdio: "inherit" });
 }, 120_000);
 
 describe("codebase-intelligence --help", () => {

--- a/tests/fixture-smoke.test.ts
+++ b/tests/fixture-smoke.test.ts
@@ -25,7 +25,7 @@ describe("fixture-codebase smoke test", () => {
     expect(fs.existsSync(getFixtureSrcPath())).toBe(true);
   });
 
-  it("pipeline parses fixture without errors", { timeout: 30_000 }, () => {
+  it("pipeline parses fixture without errors", { timeout: 60_000 }, () => {
     const { parsedFiles } = getFixturePipeline();
     expect(parsedFiles.length).toBeGreaterThan(0);
   });

--- a/tests/phase1-red.test.ts
+++ b/tests/phase1-red.test.ts
@@ -40,7 +40,7 @@ interface ExpectedSymbolsFile {
 }
 
 describe("1.1 — parser re-export resolution", () => {
-  it("barrel index.ts files expose transitive exports", { timeout: 30_000 }, () => {
+  it("barrel index.ts files expose transitive exports", { timeout: 60_000 }, () => {
     const { parsedFiles } = getFixturePipeline();
     const authIndex = parsedFiles.find((f) => f.relativePath === "auth/index.ts");
     expect(authIndex).toBeDefined();

--- a/tests/rules-engine.test.ts
+++ b/tests/rules-engine.test.ts
@@ -256,7 +256,12 @@ describe("new-only gate", () => {
     GIT_COMMITTER_EMAIL: "t@example.com",
   };
   function git(dir: string, args: string[]): string {
-    return execFileSync("git", args, { cwd: dir, encoding: "utf-8", env: GIT_ENV, stdio: ["ignore", "pipe", "ignore"] }).trim();
+    return execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+      cwd: dir,
+      encoding: "utf-8",
+      env: GIT_ENV,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
   }
 
   it("filters findings to files changed since base", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
-    testTimeout: 15000,
-    hookTimeout: 15000,
+    testTimeout: 60000,
+    hookTimeout: 60000,
     teardownTimeout: 30000,
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary
- bump package base to 2.5.0 for main-branch canary publishing only; no stable release/tag
- fix CLI target-root handling, exact path lookup, parent .gitignore parsing, --force propagation
- reject invalid enum-like CLI options for hotspots --metric, changes --scope, check --gate
- document full CLI/MCP surface and make pnpm test rebuild dist with stable Vitest runner flags

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- real dist CLI smoke: 53/53 across this repo, create-vllnt-app/cli, create-vllnt-app/www, temp init repo

## Release
- Canary mode only. Merging to main publishes 2.5.0-canary.<sha> via the existing publish workflow.
- Do not run the manual release workflow for stable 2.5.0 from this PR.