### PR TITLE
feat(core): improve real-repo analysis resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Common workflows:
 
 ```bash
 npx codebase-intelligence hotspots ./src --metric complexity --limit 10
+npx codebase-intelligence opportunities ./src --limit 10
 npx codebase-intelligence impact ./src parseCodebase
 npx codebase-intelligence dead-exports ./src --limit 20
 npx codebase-intelligence changes ./src --json
@@ -55,7 +56,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 
 ## Features
 
-- **17 CLI commands** for architecture analysis, dependency impact, dead code detection, search, CI rules, and agent setup
+- **18 CLI commands** for architecture analysis, dependency impact, improvement opportunities, dead code detection, search, CI rules, and agent setup
 - **Machine-readable JSON output** (`--json`) for automation and CI pipelines
 - **Auto-cached index** in `.code-visualizer/` for fast repeat queries
 - **11 architectural metrics** — PageRank, betweenness, coupling, cohesion, tension, churn, complexity, blast radius, dead exports, test coverage, escape velocity
@@ -64,7 +65,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 - **Process tracing** — detect entry points and execution flows through the call graph
 - **Community detection** — Louvain clustering for natural file groupings
 - **Agent adoption** — `init` writes per-agent instruction files + installs a skill so AI agents query CI before grep/read
-- **MCP parity (secondary)** — same analysis and rules gate available as 16 MCP tools, 2 prompts, and 3 resources
+- **MCP parity (secondary)** — same analysis and rules gate available as 17 MCP tools, 2 prompts, and 3 resources
 
 ## Installation
 
@@ -100,6 +101,7 @@ codebase-intelligence <command> <path> [options]
 | `modules` | Module architecture + cross-dependencies |
 | `forces` | Cohesion/tension/escape-velocity analysis |
 | `dead-exports` | Unused export detection |
+| `opportunities` | Ranked code-quality and refactoring opportunities |
 | `groups` | Top-level directory groups + aggregate metrics |
 | `symbol` | Callers/callees and symbol metrics |
 | `impact` | Symbol-level blast radius |
@@ -118,6 +120,8 @@ codebase-intelligence <command> <path> [options]
 | `--limit <n>` | Limit results on supported commands |
 | `--metric <m>` | Select ranking metric for `hotspots` |
 | `--scope <s>` | Select git diff scope for `changes`: `staged`, `unstaged`, `all` |
+
+The scanner always excludes common generated and agent-workspace directories such as `.code-visualizer/`, `.next/`, `dist/`, `coverage/`, `.worktrees/`, and `.claude/worktrees/`.
 
 For full command details, see [docs/cli-reference.md](docs/cli-reference.md).
 
@@ -304,6 +308,8 @@ pnpm test         # vitest
 pnpm lint         # eslint
 pnpm typecheck    # tsc --noEmit
 pnpm build        # production build
+pnpm verify:cli-real        # default real-repo CLI matrix
+pnpm verify:cli-real:heavy  # large /home/ubuntu repo matrix
 ```
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,8 @@ Core (shared computation)
   | result builders used by both MCP and CLI
   v
 MCP (stdio)                    CLI (terminal/CI)
-  | 16 tools, 2 prompts,        | 5 commands: overview, hotspots,
-  | 3 resources for LLMs        | file, search, changes + --json
+  | 17 tools, 2 prompts,        | 18 commands with text + JSON
+  | 3 resources for LLMs        | output for humans and CI
 ```
 
 ## Module Map
@@ -37,13 +37,14 @@ src/
   core/index.ts        <- Shared result computation (MCP + CLI)
   config/index.ts      <- Config discovery + zod validation
   rules/index.ts       <- Rules engine + registry (check command + MCP check tool)
-  mcp/index.ts         <- 16 MCP tools for LLM integration
+  mcp/index.ts         <- 17 MCP tools for LLM integration
   mcp/hints.ts         <- Next-step hints for MCP tool responses
   impact/index.ts      <- Symbol-level impact analysis + rename planning
   search/index.ts      <- BM25 search engine
   process/index.ts     <- Entry point detection + call chain tracing
   community/index.ts   <- Louvain clustering
   persistence/index.ts <- Graph export/import to .code-visualizer/
+  persistence/cache-key.ts <- Cache signature from HEAD, worktree content, CLI version, parser settings
   install/index.ts     <- Agent adoption: managed-block engine + per-agent file targets + skill
   server/graph-store.ts <- Global graph state (shared by CLI + MCP)
   cli.ts               <- Entry point, CLI commands + MCP fallback
@@ -66,7 +67,7 @@ analyzeGraph(builtGraph, parsedFiles)
      }
 
 startMcpServer(codebaseGraph)
-  -> stdio MCP server with 16 tools, 2 prompts, 3 resources
+  -> stdio MCP server with 17 tools, 2 prompts, 3 resources
 ```
 
 ## Key Design Decisions
@@ -74,9 +75,12 @@ startMcpServer(codebaseGraph)
 - **Dual interface**: MCP stdio for LLM agents, CLI subcommands for humans/CI. Both consume `src/core/`.
 - **graphology**: In-memory graph with O(1) neighbor lookup. PageRank and betweenness computed via graphology-metrics.
 - **Batch git churn**: Single `git log --all --name-only` call, parsed for all files. Avoids O(n) subprocess spawning.
+- **Monorepo import resolution**: Root `tsconfig.json` path aliases and local `package.json` package names resolve to source files before graph construction.
+- **Large repo fallback**: Above 1500 TypeScript files, the parser uses AST-only extraction to keep file/import/export analysis available without TypeScript program OOM.
 - **Dead export detection**: Cross-references parsed exports against edge symbol lists. May miss `import *` or re-exports (known limitation).
 - **Graceful degradation**: Non-git dirs get churn=0, no-test codebases get coverage=false. Never crashes.
-- **Graph persistence**: CLI commands always cache the graph index to `.code-visualizer/`. MCP mode (`codebase-intelligence <path>`) requires `--index` to persist the cache.
+- **Built-in scanner excludes**: Generated indexes, build outputs, coverage, framework caches, and agent worktrees are skipped before TypeScript program creation.
+- **Graph persistence**: CLI commands always cache the graph index to `.code-visualizer/`. Cache reuse requires matching HEAD, dirty/untracked file-content fingerprint, CLI version, and parser cache settings. MCP mode (`codebase-intelligence <path>`) requires `--index` to persist the cache.
 
 ## Adding a New Metric
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-17 commands for terminal and CI use. The 15 analysis commands have full parity with MCP tools and auto-cache the index to `.code-visualizer/`; `check` runs the rules gate; `init` sets up agent adoption.
+18 commands for terminal and CI use. The 16 analysis commands have full parity with MCP tools and auto-cache the index to `.code-visualizer/`; `check` runs the rules gate; `init` sets up agent adoption.
 
 ## Commands
 
@@ -12,7 +12,7 @@ High-level codebase snapshot.
 codebase-intelligence overview <path> [--json] [--force]
 ```
 
-**Output:** file count, function count, dependency count, modules (path, files, LOC, coupling, cohesion), top 5 depended files, avg LOC, max depth, circular dep count.
+**Output:** file count, function count, dependency count, analysis mode/call graph precision, modules (path, files, LOC, coupling, cohesion), top 5 depended files, avg LOC, max depth, circular dep count.
 
 ### hotspots
 
@@ -94,7 +94,17 @@ Find unused exports across the codebase.
 codebase-intelligence dead-exports <path> [--module <module>] [--limit <n>] [--json] [--force]
 ```
 
-**Output:** dead export count, files with unused exports, summary.
+**Output:** dead export count, files with unused exports, confidence, package-entrypoint evidence, summary.
+
+### opportunities
+
+Rank code quality and refactoring opportunities for AI agents.
+
+```bash
+codebase-intelligence opportunities <path> [--limit <n>] [--json] [--force]
+```
+
+**Output:** ranked opportunities with kind, priority, confidence, score, target, evidence, and suggested follow-up commands.
 
 ### groups
 
@@ -198,7 +208,7 @@ codebase-intelligence init [path] [--agents <list>] [--all] [--skill] [--yes] [-
 | `--json` | All commands | Output stable JSON to stdout |
 | `--force` | All commands | Re-parse even if cached index matches HEAD |
 | `--metric <m>` | hotspots | Metric to rank by (default: coupling) |
-| `--limit <n>` | hotspots, search, dead-exports, processes | Max results |
+| `--limit <n>` | hotspots, search, dead-exports, opportunities, processes | Max results |
 | `--scope <s>` | changes | Git diff scope: staged, unstaged, all |
 | `--depth <n>` | dependents | Max traversal depth (default: 2) |
 | `--cohesion <n>` | forces | Min cohesion threshold (default: 0.6) |
@@ -221,7 +231,11 @@ codebase-intelligence init [path] [--agents <list>] [--all] [--skill] [--yes] [-
 
 ## Behavior
 
-**Auto-caching:** First CLI invocation parses the codebase and saves the index to `.code-visualizer/`. Subsequent commands use the cache if `git HEAD` hasn't changed. Add `.code-visualizer/` to `.gitignore`.
+**Auto-caching:** First CLI invocation parses the codebase and saves the index to `.code-visualizer/`. Subsequent commands use the cache only when `git HEAD`, dirty/untracked file contents under the analyzed path, the CLI version, and parser cache settings match. Add `.code-visualizer/` to `.gitignore`.
+
+**Default scanner excludes:** The parser always skips `.git`, `node_modules`, `.code-visualizer`, `.next`, `dist`, `coverage`, `.turbo`, `.cache`, `.worktrees`, and `.claude/worktrees`, even if the target repo has no matching `.gitignore` entry.
+
+**Large repo mode:** Repos above 1500 TypeScript files use a lightweight AST parser by default to avoid TypeScript program OOM. File/import/export/dependency metrics remain available; type-resolved call graph details are reduced. Set `CBI_FULL_PROGRAM_FILE_LIMIT=<n>` to tune the cutoff.
 
 **stdout/stderr:** Results go to stdout. Progress messages go to stderr. Safe for piping (`| jq`, `> file.json`).
 
@@ -234,4 +248,4 @@ codebase-intelligence init [path] [--agents <list>] [--all] [--skill] [--yes] [-
 - `--index` — persist graph index to `.code-visualizer/` (CLI auto-caches, MCP requires this flag)
 - `--status` — print index status and exit
 - `--clean` — remove `.code-visualizer/` index and exit
-- `--force` — re-index even if HEAD unchanged
+- `--force` — re-index even if the cache signature matches

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -76,6 +76,9 @@ FileMetrics {
   cyclomaticComplexity: number  // Avg complexity of exports
   blastRadius: number           // Transitive dependent count
   deadExports: string[]         // Unused export names
+  totalExports: number          // Named export count used as dead-export denominator
+  isPackageEntrypoint: boolean  // package.json exports/main/types/bin point here
+  packageEntrypointReason: string // package.json field/path evidence
   isTestFile: boolean           // Whether this file is a test file
 }
 
@@ -107,6 +110,9 @@ CodebaseGraph {
     totalFunctions: number
     totalDependencies: number
     circularDeps: string[][]  // Each cycle = array of file paths
+    analysisMode: "full-program" | "ast-only"
+    callGraphPrecision: "type-resolved" | "syntax-only"
+    fullProgramFileLimit: number
   }
 }
 ```

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,13 +1,13 @@
 # MCP Tools Reference
 
-16 tools available via MCP stdio.
+17 tools available via MCP stdio.
 
 ## 1. codebase_overview
 
 High-level summary of the entire codebase.
 
 **Input:** `{ depth?: number }`
-**Returns:** totalFiles, totalFunctions, totalDependencies, modules (sorted by size), topDependedFiles (top 5 by fanIn), globalMetrics (avgLOC, maxDepth, circularDepCount)
+**Returns:** totalFiles, totalFunctions, totalDependencies, modules (sorted by size), topDependedFiles (top 5 by fanIn), metrics (avgLOC, maxDepth, circularDeps), analysis (mode, callGraphPrecision, fullProgramFileLimit)
 
 **Use when:** First exploring a codebase. "What does this project look like?"
 **Not for:** Module details (use get_module_structure) or data flow (use analyze_forces).
@@ -17,7 +17,7 @@ High-level summary of the entire codebase.
 Detailed context for a single file.
 
 **Input:** `{ filePath: string }` (relative path)
-**Returns:** path, loc, exports, imports (with symbols, isTypeOnly, weight), dependents (with symbols, isTypeOnly, weight), metrics (all FileMetrics including churn, complexity, blastRadius, deadExports, hasTests, testFile)
+**Returns:** path, loc, exports, imports (with symbols, isTypeOnly, weight), dependents (with symbols, isTypeOnly, weight), metrics (all FileMetrics including churn, complexity, blastRadius, deadExports, totalExports, package-entrypoint metadata, hasTests, testFile)
 
 **Path normalization:** Backslashes are normalized to forward slashes. The exact graph path is tried first; if not found, common prefixes (`src/`, `lib/`, `app/`) are stripped once from the leading position and retried. If the file is not found, the error includes up to 3 suggested similar paths.
 
@@ -70,12 +70,24 @@ Architectural force analysis — module health, misplaced files, bridge files.
 Find unused exports across the codebase.
 
 **Input:** `{ module?: string, limit?: number }` (default limit: 20)
-**Returns:** totalDeadExports, files (with path, module, deadExports[], totalExports), summary
+**Returns:** totalDeadExports, files (with path, module, deadExports[], totalExports, confidence, package-entrypoint metadata), summary
+
+Package public entrypoints from `exports`, `main`, `types`, and `bin` are reported as low confidence because external consumers may use them.
 
 **Use when:** Cleaning up dead code, reducing API surface.
 **Not for:** Finding used exports (use file_context).
 
-## 8. get_groups
+## 8. find_opportunities
+
+Rank code quality and refactoring opportunities for AI agents.
+
+**Input:** `{ limit?: number }` (default limit: 20)
+**Returns:** totalOpportunities, opportunities[] (rank, kind, target, title, priority, score, confidence, why, evidence[], suggestedCommands[]), summary
+
+**Use when:** "What should I improve?" "Find refactoring opportunities." "Which files need tests?"
+**Not for:** Raw metric lists only (use find_hotspots or analyze_forces).
+
+## 9. get_groups
 
 Top-level directory groups with aggregate metrics.
 
@@ -85,7 +97,7 @@ Top-level directory groups with aggregate metrics.
 **Use when:** "What are the main areas of this codebase?" High-level grouping overview.
 **Not for:** Detailed module metrics (use get_module_structure).
 
-## 9. symbol_context
+## 10. symbol_context
 
 Callers, callees, and importance metrics for a function, class, or method.
 
@@ -95,7 +107,7 @@ Callers, callees, and importance metrics for a function, class, or method.
 **Use when:** "Who calls X?" "Trace this function." "What depends on this symbol?"
 **Not for:** Text search (use search) or file-level dependencies (use get_dependents).
 
-## 10. search
+## 11. search
 
 Search files and symbols by keyword.
 
@@ -105,7 +117,7 @@ Search files and symbols by keyword.
 **Use when:** "Find files related to auth." "Where is getUserById defined?"
 **Not for:** Structured call graph queries (use symbol_context).
 
-## 11. detect_changes
+## 12. detect_changes
 
 Detect changed files from git diff with risk metrics.
 
@@ -115,7 +127,7 @@ Detect changed files from git diff with risk metrics.
 **Use when:** Starting a review, triaging changes, "what changed?"
 **Not for:** Symbol-level impact (use impact_analysis).
 
-## 12. impact_analysis
+## 13. impact_analysis
 
 Symbol-level blast radius with depth-grouped risk labels.
 
@@ -125,7 +137,7 @@ Symbol-level blast radius with depth-grouped risk labels.
 **Use when:** "What breaks if I change getUserById?" Symbol-level impact assessment.
 **Not for:** File-level dependencies (use get_dependents).
 
-## 13. rename_symbol
+## 14. rename_symbol
 
 Read-only reference finder for rename planning.
 
@@ -135,7 +147,7 @@ Read-only reference finder for rename planning.
 **Use when:** Planning a rename, finding all usages of a symbol.
 **Not for:** Call graph analysis (use symbol_context).
 
-## 14. get_processes
+## 15. get_processes
 
 Trace execution flows from entry points through the call graph.
 
@@ -145,7 +157,7 @@ Trace execution flows from entry points through the call graph.
 **Use when:** "How does this app start?" "Trace request flow." "What are the entry points?"
 **Not for:** Static file dependencies (use get_dependents).
 
-## 15. get_clusters
+## 16. get_clusters
 
 Community-detected clusters of related files.
 
@@ -155,7 +167,7 @@ Community-detected clusters of related files.
 **Use when:** "What files are related?" "Find natural groupings." Discovering emergent groupings that differ from directory structure.
 **Not for:** Directory-based modules (use get_module_structure).
 
-## 16. check
+## 17. check
 
 Run the configurable rules engine and gate on findings.
 
@@ -192,6 +204,8 @@ Rules: `no-comments` (off by default), `no-circular-deps` (error), `no-dead-expo
 | "What breaks if I change function X?" | `impact_analysis` |
 | "What are the riskiest files?" | `find_hotspots` (coupling, churn, or blast_radius) |
 | "Which files need tests?" | `find_hotspots` (coverage) |
+| "What should I improve first?" | `find_opportunities` |
+| "Find refactoring opportunities." | `find_opportunities` |
 | "What can I safely delete?" | `find_dead_exports` |
 | "How are modules organized?" | `get_module_structure` |
 | "What's architecturally wrong?" | `analyze_forces` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,8 +25,8 @@ Analyzer
   | produces: ForceAnalysis (tension files, bridges, extraction candidates)
   v
 MCP (stdio) + CLI
-  | MCP: 16 tools, 2 prompts, 3 resources for LLM agents
-  | CLI: 17 commands with formatted + JSON output for humans/CI
+  | MCP: 17 tools, 2 prompts, 3 resources for LLM agents
+  | CLI: 18 commands with formatted + JSON output for humans/CI
 ```
 
 ## Module Map
@@ -38,13 +38,14 @@ src/
   graph/index.ts       <- graphology graph + circular dep detection
   analyzer/index.ts    <- All metric computation
   core/index.ts        <- Shared result computation (MCP + CLI)
-  mcp/index.ts         <- 16 MCP tools for LLM integration
+  mcp/index.ts         <- 17 MCP tools for LLM integration
   mcp/hints.ts         <- Next-step hints for MCP tool responses
   impact/index.ts      <- Symbol-level impact analysis + rename planning
   search/index.ts      <- BM25 search engine
   process/index.ts     <- Entry point detection + call chain tracing
   community/index.ts   <- Louvain clustering
   persistence/index.ts <- Graph export/import to .code-visualizer/
+  persistence/cache-key.ts <- Cache signature from HEAD, worktree content, CLI version, parser settings
   server/graph-store.ts <- Global graph state (shared by CLI + MCP)
   cli.ts               <- Entry point, CLI commands + MCP fallback
 ```
@@ -149,6 +150,9 @@ FileMetrics {
   cyclomaticComplexity: number  // Avg complexity of exports
   blastRadius: number           // Transitive dependent count
   deadExports: string[]         // Unused export names
+  totalExports: number          // Named export count used as dead-export denominator
+  isPackageEntrypoint: boolean  // package.json exports/main/types/bin point here
+  packageEntrypointReason: string // package.json field/path evidence
   isTestFile: boolean           // Whether this file is a test
 }
 
@@ -165,6 +169,8 @@ ModuleMetrics {
   dependedBy: string[]
 }
 ```
+
+Graph stats include `analysisMode` (`full-program` or `ast-only`), `callGraphPrecision` (`type-resolved` or `syntax-only`), and `fullProgramFileLimit`. In `ast-only` mode, file/import/export/dependency metrics remain available while type-resolved call graph detail is reduced.
 
 ---
 
@@ -185,6 +191,9 @@ ModuleMetrics {
 | cyclomaticComplexity | 1-N | Avg complexity of exports |
 | blastRadius | 0-N | Transitive dependents affected by change |
 | deadExports | list | Export names not consumed by any import |
+| totalExports | count | Named exports used as dead-export denominator |
+| isPackageEntrypoint | bool | True when package.json exports/main/types/bin point at file |
+| packageEntrypointReason | string | package.json entry evidence for public API confidence |
 | hasTests | bool | Matching test file exists |
 
 ## Module Metrics
@@ -212,10 +221,10 @@ The most dangerous files have: high churn + high coupling + low coverage.
 
 # MCP Tools Reference
 
-16 tools available via MCP stdio.
+17 tools available via MCP stdio.
 
 ## 1. codebase_overview
-High-level summary. Input: `{ depth?: number }`. Returns: totalFiles, totalFunctions, modules, topDependedFiles, metrics.
+High-level summary. Input: `{ depth?: number }`. Returns: totalFiles, totalFunctions, modules, topDependedFiles, metrics, and analysis mode/call graph precision.
 
 ## 2. file_context
 Detailed file context. Input: `{ filePath: string }`. Returns: exports, imports, dependents, all FileMetrics.
@@ -233,31 +242,37 @@ Module architecture. Input: `{ depth?: number }`. Returns: modules with metrics,
 Architectural force analysis. Input: `{ cohesionThreshold?, tensionThreshold?, escapeThreshold? }`. Returns: cohesion verdicts, tension files, bridge files, extraction candidates.
 
 ## 7. find_dead_exports
-Unused exports. Input: `{ module?: string, limit?: number }`. Returns: files with dead exports.
+Unused exports. Input: `{ module?: string, limit?: number }`. Returns: files with dead exports plus confidence. Package public entrypoints from `exports`, `main`, `types`, and `bin` are low confidence because external consumers may use them.
 
-## 8. get_groups
+## 8. find_opportunities
+Rank code quality and refactoring opportunities. Input: `{ limit?: number }`. Returns: ranked opportunities with priority, confidence, evidence, and suggested commands.
+
+## 9. get_groups
 Top-level directory groups. Input: `{}`. Returns: groups with rank, files, loc, importance, coupling.
 
-## 9. symbol_context
+## 10. symbol_context
 Function/class context. Input: `{ name: string }`. Returns: callers, callees, metrics.
 
-## 10. search
+## 11. search
 Keyword search (BM25). Input: `{ query: string, limit?: number }`. Returns: ranked files + symbols.
 
-## 11. detect_changes
+## 12. detect_changes
 Git diff analysis. Input: `{ scope?: "staged" | "unstaged" | "all" }`. Returns: changed files, affected files, risk metrics.
 
-## 12. impact_analysis
+## 13. impact_analysis
 Symbol-level blast radius. Input: `{ symbol: string }`. Returns: depth-grouped impact levels.
 
-## 13. rename_symbol
+## 14. rename_symbol
 Reference finder for rename planning. Input: `{ oldName: string, newName: string, dryRun?: boolean }`. Returns: references with confidence.
 
-## 14. get_processes
+## 15. get_processes
 Entry point execution flows. Input: `{ entryPoint?: string, limit?: number }`. Returns: processes with steps and depth.
 
-## 15. get_clusters
+## 16. get_clusters
 Community-detected file clusters. Input: `{ minFiles?: number }`. Returns: clusters with cohesion.
+
+## 17. check
+Rules-engine gate. Input: `{}`. Returns: pass/warn/fail verdict, findings, config path, and summary counts.
 
 ## Tool Selection Guide
 
@@ -269,6 +284,8 @@ Community-detected file clusters. Input: `{ minFiles?: number }`. Returns: clust
 | What breaks if I change function X? | impact_analysis |
 | What are the riskiest files? | find_hotspots |
 | Which files need tests? | find_hotspots (coverage) |
+| What should I improve first? | find_opportunities |
+| Find refactoring opportunities | find_opportunities |
 | What can I safely delete? | find_dead_exports |
 | How are modules organized? | get_module_structure |
 | What's architecturally wrong? | analyze_forces |
@@ -278,12 +295,13 @@ Community-detected file clusters. Input: `{ minFiles?: number }`. Returns: clust
 | Find all references to X | rename_symbol |
 | How does data flow? | get_processes |
 | What files naturally belong together? | get_clusters |
+| What rule violations exist? | check |
 
 ---
 
 # CLI Reference
 
-17 commands — 15 analysis commands (full parity with MCP tools), `check` for CI rules, and `init` for agent adoption.
+18 commands — 16 analysis commands (full parity with MCP tools), `check` for CI rules, and `init` for agent adoption.
 
 ## Commands
 
@@ -340,6 +358,12 @@ Architectural force analysis: tension files, bridges, extraction candidates.
 codebase-intelligence dead-exports <path> [--module <m>] [--limit <n>] [--json] [--force]
 ```
 Find unused exports across the codebase.
+
+### opportunities
+```bash
+codebase-intelligence opportunities <path> [--limit <n>] [--json] [--force]
+```
+Rank code quality and refactoring opportunities with evidence, confidence, and suggested commands.
 
 ### groups
 ```bash
@@ -400,7 +424,11 @@ Gate modes: all, new-only. Returns pass/warn/fail verdict, findings, and summary
 
 ## Global Behavior
 
-- **Auto-caching**: First run parses and saves index to `.code-visualizer/`. Subsequent runs use cache if HEAD unchanged.
+- **Auto-caching**: First run parses and saves index to `.code-visualizer/`. Subsequent runs use cache only when HEAD, dirty/untracked file contents under the analyzed path, CLI version, and parser cache settings match.
+- **Default scanner excludes**: `.git`, `node_modules`, `.code-visualizer`, `.next`, `dist`, `coverage`, `.turbo`, `.cache`, `.worktrees`, and `.claude/worktrees`.
+- **Monorepo imports**: Root tsconfig path aliases and local package.json package names resolve to source files before graph construction.
+- **Large repo mode**: Above 1500 TypeScript files, use AST-only extraction to avoid TypeScript program OOM. Override with `CBI_FULL_PROGRAM_FILE_LIMIT`.
+- **Real-repo verification**: `pnpm verify:cli-real` runs the default matrix. `pnpm verify:cli-real:heavy` sets `CBI_REAL_PROFILE=heavy` and verifies large `/home/ubuntu` repos with minimum file/dependency thresholds.
 - **Progress**: All progress messages go to stderr. Results go to stdout.
 - **JSON mode**: `--json` outputs stable JSON schema to stdout.
 - **Exit codes**: 0 = success, 1 = runtime error, 2 = bad args/usage.

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 - [Architecture](docs/architecture.md): Pipeline, module map, data flow, design decisions
 - [Data Model](docs/data-model.md): All TypeScript interfaces with field descriptions
 - [Metrics](docs/metrics.md): Per-file and module metrics, force analysis, complexity scoring
-- [MCP Tools](docs/mcp-tools.md): 16 MCP tools — inputs, outputs, use cases, selection guide
+- [MCP Tools](docs/mcp-tools.md): 17 MCP tools — inputs, outputs, use cases, selection guide
 - [CLI Reference](docs/cli-reference.md): CLI commands, flags, output formats, examples
 
 ## Quick Start
@@ -17,7 +17,7 @@ MCP mode (AI agents):
 codebase-intelligence ./path/to/project
 ```
 
-CLI mode (humans/CI) — 17 commands (15 analysis with MCP parity + `check` + `init`):
+CLI mode (humans/CI) — 18 commands (16 analysis with MCP parity + `check` + `init`):
 ```bash
 codebase-intelligence overview ./src
 codebase-intelligence hotspots ./src --metric coupling
@@ -28,6 +28,7 @@ codebase-intelligence dependents ./src types.ts --depth 3
 codebase-intelligence modules ./src
 codebase-intelligence forces ./src
 codebase-intelligence dead-exports ./src
+codebase-intelligence opportunities ./src --limit 10
 codebase-intelligence groups ./src
 codebase-intelligence symbol ./src parseCodebase
 codebase-intelligence impact ./src getUserById
@@ -37,6 +38,11 @@ codebase-intelligence clusters ./src --min-files 3
 codebase-intelligence check ./src                      # rules gate for CI
 codebase-intelligence init .                         # make AI agents use CI
 ```
+
+## Behavior Notes
+
+- `overview --json` includes `analysis.mode`, `analysis.callGraphPrecision`, and `analysis.fullProgramFileLimit`.
+- Repos above the full-program file limit use AST-only extraction; dependency metrics remain available, call graph precision becomes syntax-only.
 
 ## Optional
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "pnpm build && vitest run --pool forks --no-file-parallelism",
     "test:coverage": "pnpm build && vitest run --coverage --pool threads --no-file-parallelism --exclude 'tests/*.e2e.test.ts'",
     "verify:cli-real": "pnpm build && node tools/verify-cli-real-codebases.mjs",
+    "verify:cli-real:heavy": "pnpm build && CBI_REAL_PROFILE=heavy node tools/verify-cli-real-codebases.mjs",
     "test:watch": "vitest",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2,6 +2,7 @@ import type Graph from "graphology";
 import pagerank from "graphology-metrics/centrality/pagerank.js";
 import betweennessCentrality from "graphology-metrics/centrality/betweenness.js";
 import path from "path";
+import fs from "fs";
 import type {
   ParsedFile,
   FileMetrics,
@@ -18,15 +19,22 @@ import type {
   CodebaseGraph,
   GraphNode,
   SymbolMetrics,
+  AnalysisMode,
+  CallGraphPrecision,
 } from "../types/index.js";
 import { type BuiltGraph, detectCircularDeps } from "../graph/index.js";
 import { cloudGroup } from "../cloud-group.js";
 import { traceProcesses } from "../process/index.js";
 import { detectCommunities } from "../community/index.js";
+import { getFullProgramFileLimit } from "../parser/index.js";
 
 export function analyzeGraph(built: BuiltGraph, parsedFiles?: ParsedFile[]): CodebaseGraph {
   const { graph, nodes, edges } = built;
   const fileNodes = nodes.filter((n) => n.type === "file");
+  const analysisMode: AnalysisMode = parsedFiles?.some((file) => file.analysisMode === "ast-only")
+    ? "ast-only"
+    : "full-program";
+  const callGraphPrecision: CallGraphPrecision = analysisMode === "ast-only" ? "syntax-only" : "type-resolved";
 
   // Build lookup from parsed files
   const parsedByPath = new Map<string, ParsedFile>();
@@ -35,6 +43,7 @@ export function analyzeGraph(built: BuiltGraph, parsedFiles?: ParsedFile[]): Cod
       parsedByPath.set(f.relativePath, f);
     }
   }
+  const packageEntrypoints = detectPackageEntrypoints(parsedFiles);
 
   // Build set of all consumed symbols (for dead export detection)
   const consumedSymbols = new Map<string, Set<string>>();
@@ -83,6 +92,8 @@ export function analyzeGraph(built: BuiltGraph, parsedFiles?: ParsedFile[]): Cod
           .filter((e) => !e.isDefault && !consumed.has(e.name))
           .map((e) => e.name)
       : [];
+    const totalExports = parsed?.exports.filter((e) => !e.isDefault).length ?? 0;
+    const packageEntrypointReason = packageEntrypoints.get(node.id) ?? "";
 
     fileMetrics.set(node.id, {
       pageRank: pr,
@@ -96,6 +107,9 @@ export function analyzeGraph(built: BuiltGraph, parsedFiles?: ParsedFile[]): Cod
       cyclomaticComplexity: Math.round(avgComplexity * 100) / 100,
       blastRadius: 0, // computed after all nodes are processed
       deadExports,
+      totalExports,
+      isPackageEntrypoint: packageEntrypointReason.length > 0,
+      packageEntrypointReason,
       hasTests: parsed?.testFile !== undefined,
       testFile: parsed?.testFile ?? "",
       isTestFile: parsed?.isTestFile ?? false,
@@ -165,6 +179,9 @@ export function analyzeGraph(built: BuiltGraph, parsedFiles?: ParsedFile[]): Cod
       totalFunctions: nodes.filter((n) => n.type === "function" || n.type === "class").length,
       totalDependencies: edges.length,
       circularDeps,
+      analysisMode,
+      callGraphPrecision,
+      fullProgramFileLimit: getFullProgramFileLimit(),
     },
   };
 
@@ -173,6 +190,169 @@ export function analyzeGraph(built: BuiltGraph, parsedFiles?: ParsedFile[]): Cod
   partialGraph.clusters = detectCommunities(partialGraph);
 
   return partialGraph;
+}
+
+interface PackageJsonShape {
+  main?: unknown;
+  module?: unknown;
+  types?: unknown;
+  typings?: unknown;
+  bin?: unknown;
+  exports?: unknown;
+}
+
+function detectPackageEntrypoints(parsedFiles?: ParsedFile[]): Map<string, string> {
+  const entrypoints = new Map<string, string>();
+  if (!parsedFiles || parsedFiles.length === 0) return entrypoints;
+
+  const rootDir = inferRootDir(parsedFiles[0]);
+  if (!rootDir) return entrypoints;
+
+  const parsedPaths = new Set(parsedFiles.map((file) => file.relativePath));
+  const packageDirs = findPackageDirs(rootDir, parsedFiles);
+
+  for (const packageDir of packageDirs) {
+    const packageJsonPath = path.join(packageDir, "package.json");
+    const packageJson = readPackageJson(packageJsonPath);
+    if (!packageJson) continue;
+
+    const entries = collectPackageEntryPaths(packageJson);
+    for (const entry of entries) {
+      const matchedPath = resolveEntrypointPath(rootDir, packageDir, entry, parsedPaths);
+      if (matchedPath && !entrypoints.has(matchedPath)) {
+        const packageRelative = normalizePath(path.relative(rootDir, packageJsonPath));
+        entrypoints.set(matchedPath, `${packageRelative}:${entry}`);
+      }
+    }
+  }
+
+  return entrypoints;
+}
+
+function inferRootDir(file: ParsedFile): string {
+  const absolutePath = path.resolve(file.path);
+  const relativePath = file.relativePath.split("/").join(path.sep);
+  if (absolutePath.endsWith(relativePath)) {
+    return absolutePath.slice(0, absolutePath.length - relativePath.length).replace(/[\\/]+$/, "");
+  }
+  return path.dirname(absolutePath);
+}
+
+function findPackageDirs(rootDir: string, parsedFiles: ParsedFile[]): Set<string> {
+  const packageDirs = new Set<string>();
+  const root = path.resolve(rootDir);
+
+  for (const file of parsedFiles) {
+    let current = path.dirname(path.resolve(file.path));
+    while (current.startsWith(root)) {
+      if (fs.existsSync(path.join(current, "package.json"))) packageDirs.add(current);
+      if (current === root) break;
+      current = path.dirname(current);
+    }
+  }
+
+  return packageDirs;
+}
+
+function readPackageJson(packageJsonPath: string): PackageJsonShape | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    return isPackageJsonShape(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPackageJsonShape(value: unknown): value is PackageJsonShape {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectPackageEntryPaths(packageJson: PackageJsonShape): string[] {
+  const entries = new Set<string>();
+  collectEntryValue(packageJson.main, entries);
+  collectEntryValue(packageJson.module, entries);
+  collectEntryValue(packageJson.types, entries);
+  collectEntryValue(packageJson.typings, entries);
+  collectEntryValue(packageJson.bin, entries);
+  collectEntryValue(packageJson.exports, entries);
+  return [...entries];
+}
+
+function collectEntryValue(value: unknown, entries: Set<string>): void {
+  if (typeof value === "string") {
+    if (value.length > 0 && !value.startsWith("#")) entries.add(value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectEntryValue(item, entries);
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) collectEntryValue(item, entries);
+  }
+}
+
+function resolveEntrypointPath(
+  rootDir: string,
+  packageDir: string,
+  entry: string,
+  parsedPaths: Set<string>,
+): string | null {
+  for (const candidate of entrypointCandidates(entry)) {
+    const absoluteCandidate = path.resolve(packageDir, candidate);
+    if (!isInsideDir(rootDir, absoluteCandidate)) continue;
+
+    const relativeCandidate = normalizePath(path.relative(rootDir, absoluteCandidate));
+    if (parsedPaths.has(relativeCandidate)) return relativeCandidate;
+  }
+
+  return null;
+}
+
+function entrypointCandidates(entry: string): string[] {
+  const normalized = normalizePath(entry)
+    .replace(/^[.]\//, "")
+    .replace(/[?#].*$/, "");
+  if (!normalized || normalized === ".") return ["index.ts", "index.tsx", "src/index.ts", "src/index.tsx"];
+
+  const withoutExtension = stripKnownExtension(normalized);
+  const candidates = new Set<string>([
+    normalized,
+    `${withoutExtension}.ts`,
+    `${withoutExtension}.tsx`,
+    path.posix.join(withoutExtension, "index.ts"),
+    path.posix.join(withoutExtension, "index.tsx"),
+  ]);
+
+  for (const prefix of ["dist/", "build/", "lib/"]) {
+    if (!withoutExtension.startsWith(prefix)) continue;
+    const withoutPrefix = withoutExtension.slice(prefix.length);
+    candidates.add(`${withoutPrefix}.ts`);
+    candidates.add(`${withoutPrefix}.tsx`);
+    candidates.add(path.posix.join(withoutPrefix, "index.ts"));
+    candidates.add(path.posix.join(withoutPrefix, "index.tsx"));
+    candidates.add(`src/${withoutPrefix}.ts`);
+    candidates.add(`src/${withoutPrefix}.tsx`);
+    candidates.add(path.posix.join("src", withoutPrefix, "index.ts"));
+    candidates.add(path.posix.join("src", withoutPrefix, "index.tsx"));
+  }
+
+  return [...candidates];
+}
+
+function stripKnownExtension(filePath: string): string {
+  return filePath.replace(/\.(?:d\.)?(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/, "");
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function isInsideDir(parent: string, child: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 const GROUP_COLORS = [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import { analyzeGraph } from "./analyzer/index.js";
 import { startMcpServer } from "./mcp/index.js";
 import { setIndexedHead, setRoot } from "./server/graph-store.js";
 import { exportGraph, importGraph } from "./persistence/index.js";
+import { getCacheKey, INDEX_DIR_NAME } from "./persistence/cache-key.js";
 import {
   computeOverview,
   computeFileContext,
@@ -37,6 +38,7 @@ import {
   computeModuleStructure,
   computeForces,
   computeDeadExports,
+  computeOpportunities,
   computeGroups,
   computeSymbolContext,
   computeProcesses,
@@ -55,8 +57,6 @@ import { runCheck, exitCodeFor } from "./rules/check.js";
 import { formatResult, formatSummaryLine } from "./rules/format.js";
 import { ConfigError } from "./config/index.js";
 import type { CodebaseGraph, OutputFormat } from "./types/index.js";
-
-const INDEX_DIR_NAME = ".code-visualizer";
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -100,10 +100,11 @@ function loadGraph(targetPath: string, force = false): { graph: CodebaseGraph; h
 
   const indexDir = getIndexDir(targetPath);
   const headHash = getHeadHash(targetPath);
+  const cacheKey = getCacheKey(targetPath, { headHash, cliVersion: pkg.version });
 
   if (!force && headHash !== "unknown") {
     const cached = importGraph(indexDir);
-    if (cached?.headHash === headHash) {
+    if (cached?.headHash === headHash && cached.cacheKey === cacheKey) {
       progress(`Using cached index (HEAD: ${headHash.slice(0, 7)})`);
       setIndexedHead(cached.headHash);
       return { graph: cached.graph, headHash };
@@ -134,7 +135,7 @@ function loadGraph(targetPath: string, force = false): { graph: CodebaseGraph; h
 
   setIndexedHead(headHash);
 
-  exportGraph(graph, indexDir, headHash);
+  exportGraph(graph, indexDir, headHash, cacheKey);
   progress(`Index saved to ${indexDir}`);
 
   return { graph, headHash };
@@ -172,6 +173,10 @@ interface ForcesOptions extends CliCommandOptions {
 
 interface DeadExportsOptions extends CliCommandOptions {
   module?: string;
+  limit?: string;
+}
+
+interface OpportunitiesOptions extends CliCommandOptions {
   limit?: string;
 }
 
@@ -246,6 +251,7 @@ program
     output(`Files:        ${result.totalFiles}`);
     output(`Functions:    ${result.totalFunctions}`);
     output(`Dependencies: ${result.totalDependencies}`);
+    output(`Analysis:     ${result.analysis.mode} (${result.analysis.callGraphPrecision} call graph)`);
     output(`Avg LOC:      ${result.metrics.avgLOC}`);
     output(`Max Depth:    ${result.metrics.maxDepth}`);
     output(`Circular:     ${result.metrics.circularDeps}`);
@@ -725,11 +731,51 @@ program
     if (result.files.length > 0) {
       output(``);
       for (const f of result.files) {
-        output(`${f.path} (${f.deadExports.length}/${f.totalExports} unused):`);
+        output(`${f.path} (${f.deadExports.length}/${f.totalExports} unused, ${f.confidence} confidence):`);
+        if (f.packageEntrypointReason) output(`  public API: ${f.packageEntrypointReason}`);
         for (const e of f.deadExports) {
           output(`  - ${e}`);
         }
       }
+    }
+  });
+
+// ── Subcommand: opportunities ──────────────────────────────
+
+program
+  .command("opportunities")
+  .description("Rank code quality and refactoring opportunities for AI agents")
+  .argument("<path>", "Path to TypeScript codebase")
+  .option("--limit <n>", "Max opportunities (default: 20)")
+  .option("--json", "Output as JSON")
+  .option("--force", "Re-index even if HEAD unchanged")
+  .action((targetPath: string, options: OpportunitiesOptions) => {
+    const { graph } = loadGraph(targetPath, forceOption(options));
+    const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+    if (limit !== undefined && (isNaN(limit) || limit < 1)) {
+      process.stderr.write("Error: --limit must be a positive integer\n");
+      process.exit(2);
+    }
+    const result = computeOpportunities(graph, limit);
+
+    if (options.json) {
+      outputJson(result);
+      return;
+    }
+
+    output(`Opportunities (${result.opportunities.length} of ${result.totalOpportunities})`);
+    output("─".repeat(40));
+    output(result.summary);
+
+    for (const opportunity of result.opportunities) {
+      output(``);
+      output(`#${opportunity.rank} [${opportunity.priority}] ${opportunity.title}`);
+      output(`  Target:     ${opportunity.target}`);
+      output(`  Kind:       ${opportunity.kind}`);
+      output(`  Score:      ${opportunity.score.toFixed(1)} (${opportunity.confidence} confidence)`);
+      output(`  Why:        ${opportunity.why}`);
+      output(`  Evidence:   ${opportunity.evidence.join("; ")}`);
+      output(`  Next:       ${opportunity.suggestedCommands[0] ?? "Review target manually"}`);
     }
   });
 
@@ -1117,7 +1163,8 @@ program
         output(options.summary ? formatSummaryLine(result) : formatResult(result, format));
       }
 
-      process.exit(exitCodeFor(result));
+      process.exitCode = exitCodeFor(result);
+      return;
     } catch (err) {
       if (err instanceof ConfigError) {
         process.stderr.write(`Config error: ${err.message}\n`);
@@ -1163,10 +1210,12 @@ async function runMcpMode(targetPath: string, options: McpOptions): Promise<void
     const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8")) as {
       headHash: string;
       timestamp: string;
+      cacheKey?: string;
     };
     progress(`Index status:`);
     progress(`  Head:      ${meta.headHash}`);
     progress(`  Indexed:   ${meta.timestamp}`);
+    progress(`  Cache key: ${meta.cacheKey ? meta.cacheKey.slice(0, 12) : "legacy"}`);
     progress(`  Files:     ${result.graph.nodes.filter((n) => n.type === "file").length}`);
     progress(`  Symbols:   ${result.graph.symbolNodes.length}`);
     progress(`  Edges:     ${result.graph.edges.length}`);
@@ -1174,10 +1223,11 @@ async function runMcpMode(targetPath: string, options: McpOptions): Promise<void
   }
 
   const headHash = getHeadHash(targetPath);
+  const cacheKey = getCacheKey(targetPath, { headHash, cliVersion: pkg.version });
 
   if (!options.force && headHash !== "unknown") {
     const cached = importGraph(indexDir);
-    if (cached?.headHash === headHash) {
+    if (cached?.headHash === headHash && cached.cacheKey === cacheKey) {
       progress(`Using cached index (HEAD: ${headHash.slice(0, 7)})`);
       setIndexedHead(cached.headHash);
       await startMcpServer(cached.graph);
@@ -1205,7 +1255,7 @@ async function runMcpMode(targetPath: string, options: McpOptions): Promise<void
   setIndexedHead(headHash);
 
   if (options.index) {
-    exportGraph(codebaseGraph, indexDir, headHash);
+    exportGraph(codebaseGraph, indexDir, headHash, cacheKey);
     progress(`Index saved to ${indexDir}`);
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
-import type { CodebaseGraph } from "../types/index.js";
+import type { AnalysisMode, CallGraphPrecision, CodebaseGraph } from "../types/index.js";
 import { createSearchIndex, search, getSuggestions } from "../search/index.js";
 import type { SearchIndex } from "../search/index.js";
 import { impactAnalysis, renameSymbol } from "../impact/index.js";
@@ -97,6 +97,11 @@ export interface OverviewResult {
   modules: Array<{ path: string; files: number; loc: number; avgCoupling: string; cohesion: number }>;
   topDependedFiles: string[];
   metrics: { avgLOC: number; maxDepth: number; circularDeps: number };
+  analysis: {
+    mode: AnalysisMode;
+    callGraphPrecision: CallGraphPrecision;
+    fullProgramFileLimit: number;
+  };
 }
 
 export function computeOverview(graph: CodebaseGraph): OverviewResult {
@@ -131,6 +136,11 @@ export function computeOverview(graph: CodebaseGraph): OverviewResult {
       maxDepth,
       circularDeps: graph.stats.circularDeps.length,
     },
+    analysis: {
+      mode: graph.stats.analysisMode,
+      callGraphPrecision: graph.stats.callGraphPrecision,
+      fullProgramFileLimit: graph.stats.fullProgramFileLimit,
+    },
   };
 }
 
@@ -152,8 +162,12 @@ export interface FileContextResult {
     cyclomaticComplexity: number;
     blastRadius: number;
     deadExports: string[];
+    totalExports: number;
+    isPackageEntrypoint: boolean;
+    packageEntrypointReason: string;
     hasTests: boolean;
     testFile: string;
+    isTestFile: boolean;
   };
 }
 
@@ -207,8 +221,12 @@ export function computeFileContext(
       cyclomaticComplexity: metrics.cyclomaticComplexity,
       blastRadius: metrics.blastRadius,
       deadExports: metrics.deadExports,
+      totalExports: metrics.totalExports,
+      isPackageEntrypoint: metrics.isPackageEntrypoint,
+      packageEntrypointReason: metrics.packageEntrypointReason,
       hasTests: metrics.hasTests,
       testFile: metrics.testFile,
+      isTestFile: metrics.isTestFile,
     },
   };
 }
@@ -628,7 +646,15 @@ export function computeForces(
 
 export interface DeadExportsResult {
   totalDeadExports: number;
-  files: Array<{ path: string; module: string; deadExports: string[]; totalExports: number }>;
+  files: Array<{
+    path: string;
+    module: string;
+    deadExports: string[];
+    totalExports: number;
+    confidence: OpportunityConfidence;
+    isPackageEntrypoint: boolean;
+    packageEntrypointReason: string;
+  }>;
   summary: string;
 }
 
@@ -639,18 +665,25 @@ export function computeDeadExports(
 ): DeadExportsResult {
   const maxResults = limit ?? 20;
   const nodeById = buildNodeById(graph);
-  const deadFiles: Array<{ path: string; module: string; deadExports: string[]; totalExports: number }> = [];
+  const deadFiles: DeadExportsResult["files"] = [];
 
   for (const [filePath, metrics] of graph.fileMetrics) {
     if (metrics.deadExports.length === 0) continue;
     const node = nodeById.get(filePath);
     if (!node) continue;
     if (module && node.module !== module) continue;
-    const totalExports = graph.nodes.filter((n) => n.parentFile === filePath).length;
-    deadFiles.push({ path: filePath, module: node.module, deadExports: metrics.deadExports, totalExports });
+    deadFiles.push({
+      path: filePath,
+      module: node.module,
+      deadExports: metrics.deadExports,
+      totalExports: metrics.totalExports,
+      confidence: metrics.isPackageEntrypoint ? "low" : "high",
+      isPackageEntrypoint: metrics.isPackageEntrypoint,
+      packageEntrypointReason: metrics.packageEntrypointReason,
+    });
   }
 
-  deadFiles.sort((a, b) => b.deadExports.length - a.deadExports.length);
+  deadFiles.sort((a, b) => confidenceSortValue(b.confidence) - confidenceSortValue(a.confidence) || b.deadExports.length - a.deadExports.length);
   const totalDead = deadFiles.reduce((sum, f) => sum + f.deadExports.length, 0);
   const sorted = deadFiles.slice(0, maxResults);
 
@@ -660,6 +693,322 @@ export function computeDeadExports(
     summary: totalDead > 0
       ? `${totalDead} unused exports across ${sorted.length} files. Consider removing to reduce API surface.`
       : "No dead exports found.",
+  };
+}
+
+function confidenceSortValue(confidence: OpportunityConfidence): number {
+  if (confidence === "high") return 3;
+  if (confidence === "medium") return 2;
+  return 1;
+}
+
+// ── Opportunities ──────────────────────────────────────────
+
+export type OpportunityKind =
+  | "add-tests"
+  | "split-file"
+  | "stabilize-hotspot"
+  | "extract-seam"
+  | "move-file"
+  | "split-module"
+  | "reduce-api-surface";
+
+export type OpportunityPriority = "critical" | "high" | "medium" | "low";
+export type OpportunityConfidence = "high" | "medium" | "low";
+
+export interface OpportunityEntry {
+  rank: number;
+  kind: OpportunityKind;
+  target: string;
+  title: string;
+  priority: OpportunityPriority;
+  score: number;
+  confidence: OpportunityConfidence;
+  why: string;
+  evidence: string[];
+  suggestedCommands: string[];
+}
+
+export interface OpportunitiesResult {
+  totalOpportunities: number;
+  opportunities: OpportunityEntry[];
+  summary: string;
+}
+
+type OpportunityDraft = Omit<OpportunityEntry, "rank" | "priority">;
+
+function roundScore(score: number): number {
+  return Math.round(score * 10) / 10;
+}
+
+function priorityForScore(score: number): OpportunityPriority {
+  if (score >= 80) return "critical";
+  if (score >= 45) return "high";
+  if (score >= 20) return "medium";
+  return "low";
+}
+
+function isFrameworkEntrypoint(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  const basename = normalized.split("/").pop() ?? normalized;
+  return basename === "page.tsx"
+    || basename === "page.ts"
+    || basename === "layout.tsx"
+    || basename === "layout.ts"
+    || basename === "route.ts"
+    || basename === "route.tsx"
+    || basename === "template.tsx"
+    || basename === "error.tsx"
+    || basename === "loading.tsx"
+    || basename === "not-found.tsx"
+    || basename === "global-error.tsx"
+    || basename === "instrumentation.ts";
+}
+
+function addOpportunity(
+  opportunities: Map<string, OpportunityDraft>,
+  opportunity: OpportunityDraft,
+): void {
+  const key = `${opportunity.kind}\0${opportunity.target}`;
+  const existing = opportunities.get(key);
+  if (!existing || opportunity.score > existing.score) {
+    opportunities.set(key, {
+      ...opportunity,
+      score: roundScore(opportunity.score),
+    });
+  }
+}
+
+function selectDiverseOpportunities(sorted: OpportunityDraft[], maxResults: number): OpportunityDraft[] {
+  const selected: OpportunityDraft[] = [];
+  const overflow: OpportunityDraft[] = [];
+  const targetCounts = new Map<string, number>();
+
+  for (const opportunity of sorted) {
+    const targetCount = targetCounts.get(opportunity.target) ?? 0;
+    if (targetCount < 2) {
+      selected.push(opportunity);
+      targetCounts.set(opportunity.target, targetCount + 1);
+      if (selected.length === maxResults) return selected;
+    } else {
+      overflow.push(opportunity);
+    }
+  }
+
+  for (const opportunity of overflow) {
+    if (selected.length === maxResults) break;
+    selected.push(opportunity);
+  }
+
+  return selected.sort((left, right) => right.score - left.score);
+}
+
+export function computeOpportunities(graph: CodebaseGraph, limit?: number): OpportunitiesResult {
+  const maxResults = limit ?? 20;
+  const nodeById = buildNodeById(graph);
+  const opportunities = new Map<string, OpportunityDraft>();
+
+  for (const [filePath, metrics] of graph.fileMetrics) {
+    if (metrics.isTestFile) continue;
+
+    const node = nodeById.get(filePath);
+    const loc = node?.loc ?? 0;
+
+    if (!metrics.hasTests && (metrics.cyclomaticComplexity >= 8 || metrics.blastRadius >= 5 || metrics.fanIn >= 3)) {
+      addOpportunity(opportunities, {
+        kind: "add-tests",
+        target: filePath,
+        title: "Add regression coverage before refactoring",
+        score: metrics.cyclomaticComplexity * 2 + metrics.blastRadius + metrics.fanIn * 2 + metrics.churn,
+        confidence: "high",
+        why: "Important file has no matching test file.",
+        evidence: [
+          `complexity=${metrics.cyclomaticComplexity.toFixed(1)}`,
+          `blastRadius=${metrics.blastRadius}`,
+          `fanIn=${metrics.fanIn}`,
+          "hasTests=false",
+        ],
+        suggestedCommands: [
+          `codebase-intelligence file . ${filePath}`,
+          `codebase-intelligence dependents . ${filePath}`,
+        ],
+      });
+    }
+
+    if (metrics.cyclomaticComplexity >= 12 || loc >= 300) {
+      addOpportunity(opportunities, {
+        kind: "split-file",
+        target: filePath,
+        title: "Split complex file into smaller units",
+        score: metrics.cyclomaticComplexity * 3 + loc / 40 + metrics.tension * 20,
+        confidence: metrics.hasTests ? "high" : "medium",
+        why: "High complexity or large file size makes future changes risky.",
+        evidence: [
+          `complexity=${metrics.cyclomaticComplexity.toFixed(1)}`,
+          `loc=${loc}`,
+          `tension=${metrics.tension.toFixed(2)}`,
+        ],
+        suggestedCommands: [
+          `codebase-intelligence file . ${filePath}`,
+          "codebase-intelligence hotspots . --metric complexity --limit 10",
+        ],
+      });
+    }
+
+    if (metrics.blastRadius >= 15 || metrics.fanIn >= 10 || metrics.isBridge) {
+      addOpportunity(opportunities, {
+        kind: "stabilize-hotspot",
+        target: filePath,
+        title: "Stabilize high-blast-radius file",
+        score: metrics.blastRadius * 2 + metrics.fanIn * 2 + metrics.betweenness * 10 + (metrics.isBridge ? 15 : 0),
+        confidence: metrics.hasTests ? "high" : "medium",
+        why: "Many files depend on this file, so small changes can ripple broadly.",
+        evidence: [
+          `blastRadius=${metrics.blastRadius}`,
+          `fanIn=${metrics.fanIn}`,
+          `isBridge=${metrics.isBridge}`,
+        ],
+        suggestedCommands: [
+          `codebase-intelligence dependents . ${filePath} --depth 3`,
+          `codebase-intelligence file . ${filePath}`,
+        ],
+      });
+    }
+
+    if (metrics.deadExports.length > 0) {
+      const frameworkEntrypoint = isFrameworkEntrypoint(filePath);
+      const packageEntrypoint = metrics.isPackageEntrypoint;
+      const conventionEntrypoint = frameworkEntrypoint || packageEntrypoint;
+      addOpportunity(opportunities, {
+        kind: "reduce-api-surface",
+        target: filePath,
+        title: conventionEntrypoint ? "Audit public API surface" : "Review unused exports",
+        score: conventionEntrypoint
+          ? Math.min(metrics.deadExports.length, 30) + Math.min(metrics.fanIn, 10)
+          : metrics.deadExports.length * 6 + metrics.fanIn,
+        confidence: conventionEntrypoint ? "low" : "medium",
+        why: packageEntrypoint
+          ? "Exports look unused internally, but package consumers may rely on this public entrypoint."
+          : frameworkEntrypoint
+          ? "Exports look unused by imports, but framework entrypoints may be consumed by convention."
+          : "Unused exports increase API surface and rename/refactor cost.",
+        evidence: [
+          `deadExports=${metrics.deadExports.length}`,
+          `sample=${metrics.deadExports.slice(0, 5).join(", ")}`,
+          `frameworkEntrypoint=${frameworkEntrypoint}`,
+          `packageEntrypoint=${packageEntrypoint}`,
+          metrics.packageEntrypointReason ? `packageEntrypointReason=${metrics.packageEntrypointReason}` : "",
+        ].filter(Boolean),
+        suggestedCommands: [
+          `codebase-intelligence file . ${filePath}`,
+          packageEntrypoint ? "Review package.json exports/main/types/bin before removing symbols" : "codebase-intelligence dead-exports . --limit 20",
+        ],
+      });
+    }
+  }
+
+  for (const seam of graph.forceAnalysis.seamCandidates) {
+    addOpportunity(opportunities, {
+      kind: "extract-seam",
+      target: seam.target,
+      title: seam.scope === "module" ? "Extract module boundary seam" : "Extract file boundary seam",
+      score: seam.fanIn + seam.dependentModules * 5 + seam.exposedSymbols,
+      confidence: seam.dependentModules > 1 ? "high" : "medium",
+      why: "This target exposes symbols used across module boundaries.",
+      evidence: [
+        seam.evidence,
+        `scope=${seam.scope}`,
+        `fanIn=${seam.fanIn}`,
+        `dependentModules=${seam.dependentModules}`,
+      ],
+      suggestedCommands: [
+        "codebase-intelligence forces .",
+        seam.scope === "file"
+          ? `codebase-intelligence dependents . ${seam.target}`
+          : "codebase-intelligence modules .",
+      ],
+    });
+  }
+
+  for (const risk of graph.forceAnalysis.localityRisks) {
+    addOpportunity(opportunities, {
+      kind: "move-file",
+      target: risk.file,
+      title: "Review file placement and ownership",
+      score: risk.blastRadius * 2 + risk.tension * 25 + risk.pulledByModuleCount * 5 + (risk.isBridge ? 10 : 0),
+      confidence: risk.tension > 0.3 ? "high" : "medium",
+      why: "Dependency pulls suggest this file may sit in the wrong module or own too many concepts.",
+      evidence: [
+        risk.evidence,
+        `kind=${risk.kind}`,
+        `blastRadius=${risk.blastRadius}`,
+        `tension=${risk.tension.toFixed(2)}`,
+      ],
+      suggestedCommands: [
+        `codebase-intelligence file . ${risk.file}`,
+        "codebase-intelligence forces .",
+      ],
+    });
+  }
+
+  for (const module of graph.forceAnalysis.moduleCohesion) {
+    if (module.verdict !== "JUNK_DRAWER" || module.files < 3) continue;
+    addOpportunity(opportunities, {
+      kind: "split-module",
+      target: module.path,
+      title: "Split low-cohesion module",
+      score: module.files + module.externalDeps + (1 - module.cohesion) * 40,
+      confidence: "medium",
+      why: "Module files do not form a cohesive dependency group.",
+      evidence: [
+        `files=${module.files}`,
+        `cohesion=${module.cohesion.toFixed(2)}`,
+        `externalDeps=${module.externalDeps}`,
+      ],
+      suggestedCommands: [
+        "codebase-intelligence modules .",
+        "codebase-intelligence forces .",
+      ],
+    });
+  }
+
+  for (const candidate of graph.forceAnalysis.extractionCandidates) {
+    addOpportunity(opportunities, {
+      kind: "extract-seam",
+      target: candidate.target,
+      title: "Extract high-escape-velocity module",
+      score: candidate.escapeVelocity * 50 + candidate.dependedByModules * 5,
+      confidence: candidate.escapeVelocity >= 0.7 ? "high" : "medium",
+      why: candidate.recommendation,
+      evidence: [
+        `escapeVelocity=${candidate.escapeVelocity.toFixed(2)}`,
+        `internalDeps=${candidate.internalDeps}`,
+        `externalDeps=${candidate.externalDeps}`,
+        `dependedByModules=${candidate.dependedByModules}`,
+      ],
+      suggestedCommands: [
+        "codebase-intelligence forces .",
+        "codebase-intelligence modules .",
+      ],
+    });
+  }
+
+  const sorted = [...opportunities.values()].sort((left, right) => right.score - left.score);
+  const ranked = selectDiverseOpportunities(sorted, maxResults)
+    .map((opportunity, index): OpportunityEntry => ({
+      rank: index + 1,
+      priority: priorityForScore(opportunity.score),
+      ...opportunity,
+    }));
+
+  const summary = ranked.length > 0
+    ? `${ranked.length} ranked opportunities. Top: ${ranked[0].title} (${ranked[0].target}).`
+    : "No high-signal opportunities found.";
+
+  return {
+    totalOpportunities: opportunities.size,
+    opportunities: ranked,
+    summary,
   };
 }
 

--- a/src/mcp/hints.ts
+++ b/src/mcp/hints.ts
@@ -35,6 +35,11 @@ const TOOL_HINTS: Record<string, string[]> = {
     "Use file_context on files with dead exports to check if they're truly unused",
     "Use codebase_overview to see overall API surface reduction opportunity",
   ],
+  find_opportunities: [
+    "Use file_context on the top opportunity target before editing",
+    "Use get_dependents for stabilize-hotspot or add-tests opportunities",
+    "Use analyze_forces for extract-seam, move-file, and split-module opportunities",
+  ],
   get_groups: [
     "Use get_module_structure for detailed per-module breakdown",
     "Use find_hotspots with metric='coupling' to find cross-group coupling",

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -20,6 +20,7 @@ import {
   computeModuleStructure,
   computeForces,
   computeDeadExports,
+  computeOpportunities,
   computeGroups,
   computeSymbolContext,
   computeProcesses,
@@ -154,7 +155,23 @@ export function registerTools(server: McpServer, graph: CodebaseGraph): void {
     }
   );
 
-  // Tool 8: get_groups
+  // Tool 8: find_opportunities
+  server.tool(
+    "find_opportunities",
+    "Rank code quality and refactoring opportunities with evidence, confidence, and suggested follow-up commands. Use when: 'what should I improve', 'find refactoring opportunities', 'what needs tests'. Not for: raw metrics only (use find_hotspots or analyze_forces)",
+    {
+      limit: z.number().optional().describe("Max opportunities (default: 20)"),
+    },
+    async ({ limit }) => {
+      const result = {
+        ...computeOpportunities(graph, limit),
+        nextSteps: getHints("find_opportunities"),
+      };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // Tool 9: get_groups
   server.tool(
     "get_groups",
     "Get top-level directory groups with aggregate metrics: files, LOC, importance (PageRank), coupling. Use when: 'what are the main areas of this codebase', high-level grouping overview. Not for: detailed module metrics (use get_module_structure)",
@@ -391,13 +408,14 @@ export function registerTools(server: McpServer, graph: CodebaseGraph): void {
         modules: [...graph.moduleMetrics.keys()],
         availableTools: [
           "codebase_overview", "file_context", "get_dependents", "find_hotspots",
-          "get_module_structure", "analyze_forces", "find_dead_exports", "get_groups",
+          "get_module_structure", "analyze_forces", "find_dead_exports", "find_opportunities", "get_groups",
           "symbol_context", "search", "detect_changes", "impact_analysis", "rename_symbol",
           "get_processes", "get_clusters", "check",
         ],
         indexedHead,
         gettingStarted: [
           "Call codebase_overview for a high-level map",
+          "Use find_opportunities for a ranked improvement plan",
           "Use search to find specific files or symbols",
           "Use symbol_context to understand function call chains",
           "Use detect_changes to see what's changed since last index",

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -245,6 +245,56 @@ export const bar = foo;
     });
   });
 
+  describe("large-repo lightweight parsing", () => {
+    it("keeps imports and direct exports when full TypeScript program is disabled", () => {
+      const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebase-viz-lightweight-"));
+      const previousLimit = process.env.CBI_FULL_PROGRAM_FILE_LIMIT;
+      process.env.CBI_FULL_PROGRAM_FILE_LIMIT = "1";
+
+      try {
+        fs.writeFileSync(
+          path.join(projectDir, "utils.ts"),
+          `export function add(a: number, b: number): number {
+  if (a > b) return a + b;
+  return b + a;
+}
+
+export const VERSION = "1.0.0";
+export default class Runner {}
+`
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "main.ts"),
+          `import Runner, { add, VERSION } from "./utils.js";
+export const value = add(1, 2) + VERSION.length;
+export { Runner };
+`
+        );
+
+        const files = parseCodebase(projectDir);
+        const utils = files.find((f) => f.relativePath === "utils.ts");
+        const main = files.find((f) => f.relativePath === "main.ts");
+
+        expect(files).toHaveLength(2);
+        expect(utils?.exports).toContainEqual(expect.objectContaining({ name: "add", type: "function" }));
+        expect(utils?.exports).toContainEqual(expect.objectContaining({ name: "VERSION", type: "variable" }));
+        expect(utils?.exports).toContainEqual(expect.objectContaining({ name: "default", type: "class", isDefault: true }));
+        expect(utils?.exports.find((exp) => exp.name === "add")?.complexity).toBeGreaterThan(1);
+        expect(utils?.analysisMode).toBe("ast-only");
+        expect(main?.analysisMode).toBe("ast-only");
+        expect(main?.imports[0].resolvedFrom).toBe("utils.ts");
+        expect(main?.callSites).toHaveLength(0);
+      } finally {
+        if (previousLimit === undefined) {
+          delete process.env.CBI_FULL_PROGRAM_FILE_LIMIT;
+        } else {
+          process.env.CBI_FULL_PROGRAM_FILE_LIMIT = previousLimit;
+        }
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe("tsconfig path alias resolution", () => {
     it("resolves @/ alias imports using tsconfig paths", () => {
       const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebase-viz-alias-"));
@@ -304,6 +354,76 @@ export const bar = foo;
         const index = files.find((f) => f.relativePath === "src/index.ts");
         expect(index?.imports).toHaveLength(1);
         expect(index?.imports[0].from).toBe("@/lib/utils");
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it("prefers specific aliases over catch-all aliases", () => {
+      const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebase-viz-alias-specific-"));
+      try {
+        fs.writeFileSync(
+          path.join(projectDir, "tsconfig.json"),
+          JSON.stringify({
+            compilerOptions: {
+              paths: {
+                "*": ["./types/*"],
+                "@scope/core/*": ["./packages/core/src/*"],
+              },
+            },
+          }),
+        );
+        fs.mkdirSync(path.join(projectDir, "packages", "core", "src"), { recursive: true });
+        fs.mkdirSync(path.join(projectDir, "app"), { recursive: true });
+        fs.writeFileSync(
+          path.join(projectDir, "packages", "core", "src", "util.ts"),
+          `export function util(): string { return "ok"; }\n`,
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "app", "index.ts"),
+          `import { util } from "@scope/core/util";\nexport const value = util();\n`,
+        );
+
+        const files = parseCodebase(projectDir);
+        const app = files.find((f) => f.relativePath === "app/index.ts");
+        expect(app?.imports[0].resolvedFrom).toBe("packages/core/src/util.ts");
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it("resolves local workspace package imports from package.json names", () => {
+      const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebase-viz-workspace-alias-"));
+      try {
+        fs.writeFileSync(
+          path.join(projectDir, "package.json"),
+          JSON.stringify({ private: true, workspaces: ["packages/*"] }),
+        );
+        fs.mkdirSync(path.join(projectDir, "packages", "core", "src"), { recursive: true });
+        fs.mkdirSync(path.join(projectDir, "app"), { recursive: true });
+        fs.writeFileSync(
+          path.join(projectDir, "packages", "core", "package.json"),
+          JSON.stringify({ name: "@scope/core" }),
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "packages", "core", "src", "index.ts"),
+          `export const root = "root";\n`,
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "packages", "core", "src", "util.ts"),
+          `export const util = "util";\n`,
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "app", "index.ts"),
+          `import { root } from "@scope/core";\nimport { util } from "@scope/core/util.js";\nexport const value = root + util;\n`,
+        );
+
+        const files = parseCodebase(projectDir);
+        const app = files.find((f) => f.relativePath === "app/index.ts");
+        const rootImport = app?.imports.find((imp) => imp.from === "@scope/core");
+        const utilImport = app?.imports.find((imp) => imp.from === "@scope/core/util.js");
+        expect(rootImport?.resolvedFrom).toBe("packages/core/src/index.ts");
+        expect(utilImport?.resolvedFrom).toBe("packages/core/src/util.ts");
       } finally {
         fs.rmSync(projectDir, { recursive: true, force: true });
       }
@@ -384,6 +504,36 @@ export const bar = foo;
         fs.writeFileSync(path.join(projectDir, "index.ts"), `export const x = 1;\n`);
         fs.mkdirSync(path.join(projectDir, ".git", "objects"), { recursive: true });
         fs.writeFileSync(path.join(projectDir, ".git", "hook.ts"), `export const h = 1;\n`);
+
+        const files = parseCodebase(projectDir);
+        expect(files).toHaveLength(1);
+        expect(files[0].relativePath).toBe("index.ts");
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it("skips built-in generated and agent workspace directories without .gitignore", () => {
+      const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebase-viz-built-in-ignore-"));
+      try {
+        fs.writeFileSync(path.join(projectDir, "index.ts"), `export const x = 1;\n`);
+
+        const ignoredFiles = [
+          [".code-visualizer", "graph.ts"],
+          [".next", "types", "generated.ts"],
+          ["dist", "cli.ts"],
+          ["coverage", "report.ts"],
+          [".turbo", "cache.ts"],
+          [".cache", "artifact.ts"],
+          [".worktrees", "pr-1", "copy.ts"],
+          [".claude", "worktrees", "agent-run", "copy.ts"],
+        ];
+
+        for (const segments of ignoredFiles) {
+          const filePath = path.join(projectDir, ...segments);
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          fs.writeFileSync(filePath, `export const ignored = 1;\n`);
+        }
 
         const files = parseCodebase(projectDir);
         expect(files).toHaveLength(1);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -5,8 +5,33 @@ import { execFileSync } from "child_process";
 import type { ParsedFile, ParsedExport, ParsedImport, CallSite } from "../types/index.js";
 
 interface PathAlias {
+  pattern: string;
   prefix: string;
   baseDir: string;
+  exact: boolean;
+}
+
+const BUILT_IN_IGNORE_PATTERNS = [
+  ".git",
+  "node_modules",
+  ".code-visualizer",
+  ".next",
+  "dist",
+  "coverage",
+  ".turbo",
+  ".cache",
+  ".worktrees",
+  ".claude/worktrees",
+];
+
+const DEFAULT_FULL_PROGRAM_FILE_LIMIT = 1500;
+
+export function getFullProgramFileLimit(): number {
+  const rawLimit = process.env.CBI_FULL_PROGRAM_FILE_LIMIT;
+  if (!rawLimit) return DEFAULT_FULL_PROGRAM_FILE_LIMIT;
+
+  const parsed = Number.parseInt(rawLimit, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_FULL_PROGRAM_FILE_LIMIT;
 }
 
 function loadTsconfigPaths(rootDir: string): PathAlias[] {
@@ -27,16 +52,17 @@ function loadTsconfigPaths(rootDir: string): PathAlias[] {
 
     for (const [pattern, targets] of Object.entries(paths)) {
       if (targets.length === 0) continue;
-      const prefix = pattern.replace(/\*$/, "");
-      const target = targets[0].replace(/\*$/, "");
+      const exact = !pattern.includes("*");
+      const prefix = exact ? pattern : pattern.replace(/\*$/, "");
+      const target = exact ? targets[0] : targets[0].replace(/\*$/, "");
       const baseDir = path.resolve(rootDir, baseUrl, target);
-      aliases.push({ prefix, baseDir });
+      aliases.push({ pattern, prefix, baseDir, exact });
     }
   } catch {
     /* malformed tsconfig — skip alias resolution */
   }
 
-  return aliases;
+  return sortAliasesBySpecificity(aliases);
 }
 
 export function parseCodebase(rootDir: string): ParsedFile[] {
@@ -52,7 +78,33 @@ export function parseCodebase(rootDir: string): ParsedFile[] {
     throw new Error(`No TypeScript files found in ${rootDir}`);
   }
 
-  const pathAliases = loadTsconfigPaths(absoluteRoot);
+  const pathAliases = loadPathAliases(absoluteRoot);
+  const parsed: ParsedFile[] = [];
+
+  if (tsFiles.length > getFullProgramFileLimit()) {
+    for (const filePath of tsFiles) {
+      try {
+        const sourceText = fs.readFileSync(filePath, "utf-8");
+        const sourceFile = ts.createSourceFile(
+          filePath,
+          sourceText,
+          ts.ScriptTarget.ES2022,
+          true,
+          filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+        );
+        parsed.push({ ...parseFile(sourceFile, undefined, absoluteRoot, pathAliases), analysisMode: "ast-only" });
+      } catch {
+        console.warn(`Skipped ${path.relative(absoluteRoot, filePath)}: parse error`);
+      }
+    }
+
+    const resolved = resolveImportPaths(parsed, absoluteRoot, pathAliases);
+    const churnMap = getGitChurn(absoluteRoot);
+    return matchTestFiles(resolved).map((f) => ({
+      ...f,
+      churn: churnMap.get(f.relativePath) ?? 0,
+    }));
+  }
 
   const program = ts.createProgram(tsFiles, {
     target: ts.ScriptTarget.ES2022,
@@ -61,16 +113,14 @@ export function parseCodebase(rootDir: string): ParsedFile[] {
     allowJs: false,
     noEmit: true,
   });
-
   const checker = program.getTypeChecker();
-  const parsed: ParsedFile[] = [];
 
   for (const filePath of tsFiles) {
     const sourceFile = program.getSourceFile(filePath);
     if (!sourceFile) continue;
 
     try {
-      const result = parseFile(sourceFile, checker, absoluteRoot, pathAliases);
+      const result: ParsedFile = { ...parseFile(sourceFile, checker, absoluteRoot, pathAliases), analysisMode: "full-program" };
       parsed.push(result);
     } catch {
       console.warn(`Skipped ${path.relative(absoluteRoot, filePath)}: parse error`);
@@ -85,8 +135,76 @@ export function parseCodebase(rootDir: string): ParsedFile[] {
   }));
 }
 
+function loadPathAliases(rootDir: string): PathAlias[] {
+  return sortAliasesBySpecificity([
+    ...loadTsconfigPaths(rootDir),
+    ...loadWorkspacePackageAliases(rootDir),
+  ]);
+}
+
+function sortAliasesBySpecificity(aliases: PathAlias[]): PathAlias[] {
+  return aliases.sort((left, right) => {
+    if (left.exact !== right.exact) return left.exact ? -1 : 1;
+    return right.prefix.length - left.prefix.length;
+  });
+}
+
+function loadWorkspacePackageAliases(rootDir: string): PathAlias[] {
+  const aliases: PathAlias[] = [];
+  for (const packageJsonPath of findPackageJsonFiles(rootDir)) {
+    try {
+      const pkg: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+      if (!isRecord(pkg) || typeof pkg.name !== "string" || pkg.name.length === 0) continue;
+
+      const packageDir = path.dirname(packageJsonPath);
+      const sourceDir = path.join(packageDir, "src");
+      if (!fs.existsSync(sourceDir)) continue;
+
+      const sourceIndex = resolveExistingModulePath(path.join(sourceDir, "index"));
+      if (sourceIndex) {
+        aliases.push({ pattern: pkg.name, prefix: pkg.name, baseDir: sourceIndex, exact: true });
+      }
+      aliases.push({ pattern: `${pkg.name}/*`, prefix: `${pkg.name}/`, baseDir: sourceDir, exact: false });
+    } catch {
+      continue;
+    }
+  }
+  return aliases;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function findPackageJsonFiles(rootDir: string): string[] {
+  const files: string[] = [];
+  const visited = new Set<string>();
+  const ignorePatterns = loadGitignorePatterns(rootDir);
+
+  function walk(dir: string): void {
+    const realDir = fs.realpathSync(dir);
+    if (visited.has(realDir)) return;
+    visited.add(realDir);
+
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      const relPath = path.relative(rootDir, fullPath);
+      if (isGitignored(relPath, ignorePatterns)) continue;
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(rootDir);
+  return files;
+}
+
 function loadGitignorePatterns(rootDir: string): string[] {
-  const patterns: string[] = [];
+  const patterns = [...BUILT_IN_IGNORE_PATTERNS];
   let current = path.resolve(rootDir);
 
   for (;;) {
@@ -111,15 +229,24 @@ function loadGitignorePatterns(rootDir: string): string[] {
 }
 
 function isGitignored(relativePath: string, patterns: string[]): boolean {
+  const normalizedPath = relativePath.split(path.sep).join("/");
+  const segments = normalizedPath.split("/");
+
   for (const pattern of patterns) {
-    const clean = pattern.endsWith("/") ? pattern.slice(0, -1) : pattern;
-    // Match directory name at any level
-    const segments = relativePath.split(path.sep);
-    for (const seg of segments) {
-      if (seg === clean) return true;
+    const clean = pattern.replaceAll("\\", "/").replace(/\/+$/, "");
+    if (!clean) continue;
+
+    if (clean.includes("/")) {
+      const patternSegments = clean.split("/");
+      for (let index = 0; index <= segments.length - patternSegments.length; index += 1) {
+        if (patternSegments.every((segment, offset) => segments[index + offset] === segment)) return true;
+      }
+      if (normalizedPath === clean || normalizedPath.startsWith(`${clean}/`)) return true;
+      continue;
     }
-    // Match leading path
-    if (relativePath.startsWith(clean + path.sep) || relativePath === clean) return true;
+
+    if (segments.includes(clean)) return true;
+    if (normalizedPath === clean || normalizedPath.startsWith(`${clean}/`)) return true;
   }
   return false;
 }
@@ -143,10 +270,6 @@ function walkDir(dir: string, rootDir: string, results: string[], visited: Set<s
     const fullPath = path.join(dir, entry.name);
     const relPath = path.relative(rootDir, fullPath);
 
-    // Always skip these regardless of .gitignore
-    if (entry.name === ".git" || entry.name === "node_modules") continue;
-
-    // Check gitignore patterns
     if (isGitignored(relPath, ignorePatterns)) continue;
 
     if (entry.isSymbolicLink()) {
@@ -169,13 +292,13 @@ function walkDir(dir: string, rootDir: string, results: string[], visited: Set<s
   }
 }
 
-function parseFile(sourceFile: ts.SourceFile, checker: ts.TypeChecker, rootDir: string, aliases: PathAlias[]): ParsedFile {
+function parseFile(sourceFile: ts.SourceFile, checker: ts.TypeChecker | undefined, rootDir: string, aliases: PathAlias[]): ParsedFile {
   const filePath = sourceFile.fileName;
   const relativePath = path.relative(rootDir, filePath);
   const loc = sourceFile.getEnd() === 0 ? 0 : sourceFile.getLineAndCharacterOfPosition(sourceFile.getEnd() - 1).line + 1;
-  const exports = extractExports(sourceFile, checker);
+  const exports = checker ? extractExports(sourceFile, checker) : extractExportsSyntax(sourceFile);
   const imports = extractImports(sourceFile, aliases);
-  const callSites = extractCallSites(sourceFile, checker, rootDir);
+  const callSites = checker ? extractCallSites(sourceFile, checker, rootDir) : [];
 
   return { path: filePath, relativePath, loc, exports, imports, callSites, churn: 0, isTestFile: false };
 }
@@ -222,6 +345,78 @@ function extractExports(sourceFile: ts.SourceFile, checker: ts.TypeChecker): Par
   return exports;
 }
 
+function extractExportsSyntax(sourceFile: ts.SourceFile): ParsedExport[] {
+  const exports: ParsedExport[] = [];
+  const seen = new Set<string>();
+
+  function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+    return ts.canHaveModifiers(node) && (ts.getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false);
+  }
+
+  function addExport(name: string, type: ParsedExport["type"], node: ts.Node, isDefault = false): void {
+    if (seen.has(name)) return;
+    seen.add(name);
+
+    const startLine = sourceFile.getLineAndCharacterOfPosition(node.getStart()).line;
+    const endLine = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line;
+    exports.push({
+      name,
+      type,
+      loc: endLine - startLine + 1,
+      isDefault,
+      complexity: computeComplexity(node),
+    });
+  }
+
+  ts.forEachChild(sourceFile, (node) => {
+    const isExported = hasModifier(node, ts.SyntaxKind.ExportKeyword);
+    const isDefault = hasModifier(node, ts.SyntaxKind.DefaultKeyword);
+
+    if (ts.isFunctionDeclaration(node) && isExported) {
+      addExport(isDefault ? "default" : (node.name?.text ?? "default"), "function", node, isDefault);
+      return;
+    }
+    if (ts.isClassDeclaration(node) && isExported) {
+      addExport(isDefault ? "default" : (node.name?.text ?? "default"), "class", node, isDefault);
+      return;
+    }
+    if (ts.isInterfaceDeclaration(node) && isExported) {
+      addExport(node.name.text, "interface", node);
+      return;
+    }
+    if (ts.isTypeAliasDeclaration(node) && isExported) {
+      addExport(node.name.text, "type", node);
+      return;
+    }
+    if (ts.isEnumDeclaration(node) && isExported) {
+      addExport(node.name.text, "enum", node);
+      return;
+    }
+    if (ts.isVariableStatement(node) && isExported) {
+      for (const declaration of node.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) continue;
+        addExport(declaration.name.text, getExportType(declaration), declaration);
+      }
+      return;
+    }
+    if (ts.isExportAssignment(node)) {
+      addExport("default", "variable", node, true);
+      return;
+    }
+    if (ts.isExportDeclaration(node)) {
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const element of node.exportClause.elements) {
+          addExport(element.name.text, "variable", element);
+        }
+      } else if (!node.exportClause) {
+        addExport("*", "variable", node);
+      }
+    }
+  });
+
+  return exports;
+}
+
 function getExportType(node: ts.Declaration): ParsedExport["type"] {
   if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isArrowFunction(node)) {
     return "function";
@@ -249,7 +444,7 @@ function extractImports(sourceFile: ts.SourceFile, aliases: PathAlias[]): Parsed
 
       const from = node.moduleSpecifier.text;
       const isRelative = from.startsWith(".") || from.startsWith("/");
-      const isAliased = aliases.some((a) => from.startsWith(a.prefix));
+      const isAliased = findMatchingAlias(from, aliases) !== undefined;
       if (!isRelative && !isAliased) return;
 
       // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -280,7 +475,7 @@ function extractImports(sourceFile: ts.SourceFile, aliases: PathAlias[]): Parsed
     if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
       const from = node.moduleSpecifier.text;
       const isRelative = from.startsWith(".") || from.startsWith("/");
-      const isAliased = aliases.some((a) => from.startsWith(a.prefix));
+      const isAliased = findMatchingAlias(from, aliases) !== undefined;
       if (!isRelative && !isAliased) return;
 
       const isTypeOnly = node.isTypeOnly;
@@ -412,12 +607,31 @@ function resolveImportPaths(files: ParsedFile[], rootDir: string, aliases: PathA
 }
 
 function expandAlias(importPath: string, aliases: PathAlias[], rootDir: string): string | null {
-  for (const alias of aliases) {
-    if (importPath.startsWith(alias.prefix)) {
-      const rest = importPath.slice(alias.prefix.length);
-      const absolute = path.join(alias.baseDir, rest);
-      return "./" + path.relative(rootDir, absolute);
-    }
+  const alias = findMatchingAlias(importPath, aliases);
+  if (!alias) return null;
+
+  const rest = alias.exact ? "" : importPath.slice(alias.prefix.length);
+  const absolute = alias.exact ? alias.baseDir : path.join(alias.baseDir, rest);
+  return "./" + path.relative(rootDir, absolute);
+}
+
+function findMatchingAlias(importPath: string, aliases: PathAlias[]): PathAlias | undefined {
+  return aliases.find((alias) => alias.exact ? importPath === alias.pattern : importPath.startsWith(alias.prefix));
+}
+
+function resolveExistingModulePath(basePath: string): string | null {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    basePath.endsWith(".js") ? basePath.slice(0, -3) + ".ts" : "",
+    basePath.endsWith(".js") ? basePath.slice(0, -3) + ".tsx" : "",
+    path.join(basePath, "index.ts"),
+    path.join(basePath, "index.tsx"),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
   }
   return null;
 }

--- a/src/persistence/cache-key.ts
+++ b/src/persistence/cache-key.ts
@@ -1,0 +1,129 @@
+import fs from "fs";
+import path from "path";
+import { execFileSync } from "child_process";
+import { createHash } from "crypto";
+import { getFullProgramFileLimit } from "../parser/index.js";
+
+export const INDEX_DIR_NAME = ".code-visualizer";
+
+const CACHE_SCHEMA_VERSION = 3;
+const CACHE_FINGERPRINT_IGNORE_PATTERNS = [
+  ".git",
+  "node_modules",
+  INDEX_DIR_NAME,
+  ".next",
+  "dist",
+  "coverage",
+  ".turbo",
+  ".cache",
+  ".worktrees",
+  ".claude/worktrees",
+];
+
+interface CacheKeyOptions {
+  headHash: string;
+  cliVersion: string;
+}
+
+function hashValue(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function splitNullDelimited(value: string): string[] {
+  return value.split("\0").filter(Boolean);
+}
+
+function gitOutput(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    timeout: 5000,
+    stdio: ["ignore", "pipe", "ignore"],
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+function getGitRoot(targetPath: string): string | null {
+  try {
+    return gitOutput(path.resolve(targetPath), ["rev-parse", "--show-toplevel"]).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isFingerprintIgnoredPath(filePath: string): boolean {
+  const normalized = filePath.replaceAll("\\", "/");
+  return CACHE_FINGERPRINT_IGNORE_PATTERNS.some(
+    (pattern) => normalized === pattern || normalized.startsWith(`${pattern}/`) || normalized.includes(`/${pattern}/`),
+  );
+}
+
+function statusEntries(status: string): string[] {
+  const parts = splitNullDelimited(status);
+  const entries: string[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const record = parts[i];
+    const code = record.slice(0, 2);
+    const firstPath = record.slice(3);
+
+    if (code.startsWith("R") || code.startsWith("C")) {
+      const secondPath = parts[i + 1] ?? "";
+      i++;
+      if (!isFingerprintIgnoredPath(firstPath) && !isFingerprintIgnoredPath(secondPath)) entries.push(`${record}\0${secondPath}`);
+      continue;
+    }
+
+    if (!isFingerprintIgnoredPath(firstPath)) entries.push(record);
+  }
+
+  return entries.sort();
+}
+
+function hashFileIfPresent(root: string, relativePath: string): string {
+  if (isFingerprintIgnoredPath(relativePath)) return `${relativePath}:ignored`;
+
+  const absolutePath = path.join(root, relativePath);
+  try {
+    if (!fs.existsSync(absolutePath)) return `${relativePath}:missing`;
+    if (!fs.statSync(absolutePath).isFile()) return `${relativePath}:non-file`;
+    return `${relativePath}:${hashValue(fs.readFileSync(absolutePath))}`;
+  } catch {
+    return `${relativePath}:unreadable`;
+  }
+}
+
+function getWorktreeFingerprint(targetPath: string): string {
+  const resolved = path.resolve(targetPath);
+  const gitRoot = getGitRoot(resolved);
+  if (!gitRoot) return "no-git";
+
+  const relativeTarget = path.relative(gitRoot, resolved).replaceAll(path.sep, "/");
+  const pathspec = relativeTarget === "" ? "." : relativeTarget;
+
+  try {
+    const status = statusEntries(gitOutput(gitRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--", pathspec]));
+    const changedTracked = splitNullDelimited(gitOutput(gitRoot, ["diff", "--name-only", "-z", "HEAD", "--", pathspec]));
+    const untracked = splitNullDelimited(gitOutput(gitRoot, ["ls-files", "--others", "--exclude-standard", "-z", "--", pathspec]));
+    const contentFingerprints = [...new Set([...changedTracked, ...untracked])]
+      .filter((filePath) => !isFingerprintIgnoredPath(filePath))
+      .sort()
+      .map((filePath) => hashFileIfPresent(gitRoot, filePath));
+
+    return hashValue(JSON.stringify({ status, contentFingerprints }));
+  } catch {
+    return "unknown-worktree";
+  }
+}
+
+export function getCacheKey(targetPath: string, options: CacheKeyOptions): string {
+  return hashValue(
+    JSON.stringify({
+      cacheSchemaVersion: CACHE_SCHEMA_VERSION,
+      cliVersion: options.cliVersion,
+      fullProgramFileLimit: getFullProgramFileLimit(),
+      headHash: options.headHash,
+      worktreeFingerprint: getWorktreeFingerprint(targetPath),
+    }),
+  );
+}

--- a/src/persistence/index.ts
+++ b/src/persistence/index.ts
@@ -9,7 +9,11 @@ interface PersistedMeta {
   headHash: string;
   timestamp: string;
   version: number;
+  cacheKey?: string;
 }
+
+type PersistedStats = Omit<CodebaseGraph["stats"], "analysisMode" | "callGraphPrecision" | "fullProgramFileLimit"> &
+  Partial<Pick<CodebaseGraph["stats"], "analysisMode" | "callGraphPrecision" | "fullProgramFileLimit">>;
 
 interface PersistedGraph {
   nodes: CodebaseGraph["nodes"];
@@ -23,16 +27,17 @@ interface PersistedGraph {
   processes: CodebaseGraph["processes"];
   clusters: CodebaseGraph["clusters"];
   forceAnalysis: CodebaseGraph["forceAnalysis"];
-  stats: CodebaseGraph["stats"];
+  stats: PersistedStats;
 }
 
 interface ImportResult {
   graph: CodebaseGraph;
   headHash: string;
+  cacheKey?: string;
 }
 
 /** Export a CodebaseGraph to JSON files in the given directory. */
-export function exportGraph(graph: CodebaseGraph, dir: string, headHash: string): void {
+export function exportGraph(graph: CodebaseGraph, dir: string, headHash: string, cacheKey?: string): void {
   fs.mkdirSync(dir, { recursive: true });
 
   const persisted: PersistedGraph = {
@@ -53,8 +58,9 @@ export function exportGraph(graph: CodebaseGraph, dir: string, headHash: string)
   const meta: PersistedMeta = {
     headHash,
     timestamp: new Date().toISOString(),
-    version: 1,
+    version: 3,
   };
+  if (cacheKey) meta.cacheKey = cacheKey;
 
   fs.writeFileSync(path.join(dir, GRAPH_FILE), JSON.stringify(persisted));
   fs.writeFileSync(path.join(dir, META_FILE), JSON.stringify(meta));
@@ -72,6 +78,13 @@ export function importGraph(dir: string): ImportResult | null {
   const persisted = JSON.parse(fs.readFileSync(graphPath, "utf-8")) as PersistedGraph;
   const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8")) as PersistedMeta;
 
+  const stats: CodebaseGraph["stats"] = {
+    ...persisted.stats,
+    analysisMode: persisted.stats.analysisMode ?? "full-program",
+    callGraphPrecision: persisted.stats.callGraphPrecision ?? "type-resolved",
+    fullProgramFileLimit: persisted.stats.fullProgramFileLimit ?? 1500,
+  };
+
   const graph: CodebaseGraph = {
     nodes: persisted.nodes,
     edges: persisted.edges,
@@ -84,8 +97,8 @@ export function importGraph(dir: string): ImportResult | null {
     processes: persisted.processes,
     clusters: persisted.clusters,
     forceAnalysis: persisted.forceAnalysis,
-    stats: persisted.stats,
+    stats,
   };
 
-  return { graph, headHash: meta.headHash };
+  return { graph, headHash: meta.headHash, cacheKey: meta.cacheKey };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+export type AnalysisMode = "full-program" | "ast-only";
+export type CallGraphPrecision = "type-resolved" | "syntax-only";
+
 export interface ParsedFile {
   path: string;
   relativePath: string;
@@ -7,6 +10,7 @@ export interface ParsedFile {
   callSites: CallSite[];
   churn: number;
   isTestFile: boolean;
+  analysisMode?: AnalysisMode;
   testFile?: string;
 }
 
@@ -93,6 +97,9 @@ export interface FileMetrics {
   cyclomaticComplexity: number;
   blastRadius: number;
   deadExports: string[];
+  totalExports: number;
+  isPackageEntrypoint: boolean;
+  packageEntrypointReason: string;
   hasTests: boolean;
   testFile: string;
   isTestFile: boolean;
@@ -241,6 +248,9 @@ export interface CodebaseGraph {
     totalFunctions: number;
     totalDependencies: number;
     circularDeps: string[][];
+    analysisMode: AnalysisMode;
+    callGraphPrecision: CallGraphPrecision;
+    fullProgramFileLimit: number;
   };
 }
 

--- a/tests/cache-key.test.ts
+++ b/tests/cache-key.test.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { getCacheKey, INDEX_DIR_NAME } from "../src/persistence/cache-key.js";
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@example.com",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@example.com",
+};
+
+function git(dir: string, args: string[]): string {
+  return execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+    cwd: dir,
+    encoding: "utf-8",
+    env: GIT_ENV,
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+function initRepo(dir: string): string {
+  git(dir, ["init"]);
+  git(dir, ["config", "user.email", "t@example.com"]);
+  git(dir, ["config", "user.name", "t"]);
+  git(dir, ["add", "-A"]);
+  git(dir, ["commit", "-m", "base", "--no-gpg-sign"]);
+  return git(dir, ["rev-parse", "HEAD"]);
+}
+
+function cacheKey(dir: string, headHash: string): string {
+  return getCacheKey(dir, { headHash, cliVersion: "test-version" });
+}
+
+describe("cache key", () => {
+  it("ignores generated index files", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-cache-key-index-"));
+    try {
+      fs.writeFileSync(path.join(dir, "index.ts"), "export const value = 1;\n");
+      const headHash = initRepo(dir);
+      const before = cacheKey(dir, headHash);
+
+      const indexDir = path.join(dir, INDEX_DIR_NAME);
+      fs.mkdirSync(indexDir);
+      fs.writeFileSync(path.join(indexDir, "graph.json"), "{}\n");
+      fs.writeFileSync(path.join(indexDir, "meta.json"), "{}\n");
+
+      expect(cacheKey(dir, headHash)).toBe(before);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("changes when dirty tracked file content changes without HEAD changing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-cache-key-dirty-"));
+    try {
+      const filePath = path.join(dir, "index.ts");
+      fs.writeFileSync(filePath, "export const value = 1;\n");
+      const headHash = initRepo(dir);
+      const clean = cacheKey(dir, headHash);
+
+      fs.writeFileSync(filePath, "export const value = 2;\n");
+      const dirty = cacheKey(dir, headHash);
+      expect(dirty).not.toBe(clean);
+      expect(cacheKey(dir, headHash)).toBe(dirty);
+
+      fs.writeFileSync(filePath, "export const value = 3;\n");
+      expect(cacheKey(dir, headHash)).not.toBe(dirty);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("changes when untracked source files appear without HEAD changing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-cache-key-untracked-"));
+    try {
+      fs.writeFileSync(path.join(dir, "index.ts"), "export const value = 1;\n");
+      const headHash = initRepo(dir);
+      const before = cacheKey(dir, headHash);
+
+      fs.writeFileSync(path.join(dir, "extra.ts"), "export const extra = 2;\n");
+      expect(cacheKey(dir, headHash)).not.toBe(before);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("changes when parser cache settings change", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-cache-key-config-"));
+    const originalLimit = process.env.CBI_FULL_PROGRAM_FILE_LIMIT;
+    try {
+      fs.writeFileSync(path.join(dir, "index.ts"), "export const value = 1;\n");
+      const headHash = initRepo(dir);
+
+      process.env.CBI_FULL_PROGRAM_FILE_LIMIT = "1500";
+      const defaultLimit = cacheKey(dir, headHash);
+
+      process.env.CBI_FULL_PROGRAM_FILE_LIMIT = "1";
+      expect(cacheKey(dir, headHash)).not.toBe(defaultLimit);
+    } finally {
+      if (originalLimit === undefined) {
+        delete process.env.CBI_FULL_PROGRAM_FILE_LIMIT;
+      } else {
+        process.env.CBI_FULL_PROGRAM_FILE_LIMIT = originalLimit;
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-check.e2e.test.ts
+++ b/tests/cli-check.e2e.test.ts
@@ -109,6 +109,29 @@ describe("check command (e2e)", () => {
     expect(parsed.summary.error).toBeGreaterThanOrEqual(1);
   });
 
+  it("flushes large JSON output before exiting", async () => {
+    const files: Record<string, string> = {};
+    for (let fileIndex = 0; fileIndex < 180; fileIndex += 1) {
+      const exports = [];
+      for (let exportIndex = 0; exportIndex < 20; exportIndex += 1) {
+        exports.push(`export const dead_${fileIndex}_${exportIndex} = ${fileIndex + exportIndex};`);
+      }
+      files[`src/file-${fileIndex}.ts`] = `${exports.join("\n")}\n`;
+    }
+
+    const dir = makeProject(files, { rules: { "no-circular-deps": "off" } });
+    const { status, stdout } = await run(["check", dir, "--json"]);
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      verdict: string;
+      findings: { ruleId: string }[];
+      summary: { warn: number };
+    };
+    expect(parsed.verdict).toBe("warn");
+    expect(parsed.findings.length).toBe(3600);
+    expect(parsed.summary.warn).toBe(3600);
+  }, 90_000);
+
   it("--format sarif emits SARIF 2.1.0", async () => {
     const dir = makeProject(CIRCULAR, { rules: { "no-dead-exports": "off" } });
     const { stdout } = await run(["check", dir, "--format", "sarif"]);

--- a/tests/cli-commands.test.ts
+++ b/tests/cli-commands.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from "child_process";
+import { execFileSync, spawnSync, type SpawnSyncReturns } from "child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +15,7 @@ import {
   computeModuleStructure,
   computeForces,
   computeDeadExports,
+  computeOpportunities,
   computeGroups,
   computeSymbolContext,
   computeProcesses,
@@ -22,6 +23,30 @@ import {
   impactAnalysis,
   renameSymbol,
 } from "../src/core/index.js";
+import type { CodebaseGraph, FileMetrics } from "../src/types/index.js";
+
+function opportunityMetrics(overrides: Partial<FileMetrics>): FileMetrics {
+  return {
+    pageRank: 0,
+    betweenness: 0,
+    fanIn: 0,
+    fanOut: 0,
+    coupling: 0,
+    tension: 0,
+    isBridge: false,
+    churn: 0,
+    cyclomaticComplexity: 1,
+    blastRadius: 0,
+    deadExports: [],
+    totalExports: 0,
+    isPackageEntrypoint: false,
+    packageEntrypointReason: "",
+    hasTests: true,
+    testFile: "",
+    isTestFile: false,
+    ...overrides,
+  };
+}
 
 describe("CLI core commands (integration)", () => {
   describe("computeOverview", () => {
@@ -70,6 +95,9 @@ describe("CLI core commands (integration)", () => {
       expect(result.metrics.avgLOC).toBeGreaterThan(0);
       expect(result.metrics.maxDepth).toBeGreaterThan(0);
       expect(typeof result.metrics.circularDeps).toBe("number");
+      expect(result.analysis.mode).toBe("full-program");
+      expect(result.analysis.callGraphPrecision).toBe("type-resolved");
+      expect(result.analysis.fullProgramFileLimit).toBeGreaterThan(0);
     });
 
     it("JSON output is valid and stable schema", () => {
@@ -84,6 +112,7 @@ describe("CLI core commands (integration)", () => {
       expect(parsed).toHaveProperty("modules");
       expect(parsed).toHaveProperty("topDependedFiles");
       expect(parsed).toHaveProperty("metrics");
+      expect(parsed).toHaveProperty("analysis");
     });
   });
 
@@ -175,8 +204,12 @@ describe("CLI core commands (integration)", () => {
         expect(result.metrics).toHaveProperty("cyclomaticComplexity");
         expect(result.metrics).toHaveProperty("blastRadius");
         expect(result.metrics).toHaveProperty("deadExports");
+        expect(result.metrics).toHaveProperty("totalExports");
+        expect(result.metrics).toHaveProperty("isPackageEntrypoint");
+        expect(result.metrics).toHaveProperty("packageEntrypointReason");
         expect(result.metrics).toHaveProperty("hasTests");
         expect(result.metrics).toHaveProperty("testFile");
+        expect(result.metrics).toHaveProperty("isTestFile");
       }
     });
 
@@ -486,26 +519,81 @@ describe("CLI core commands (integration)", () => {
   });
 
   describe("overview CLI command", () => {
+    const TSX_BIN = path.join(process.cwd(), "node_modules", ".bin", "tsx");
+    const GIT_ENV = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@example.com",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@example.com",
+    };
+
+    function git(dir: string, args: string[]): string {
+      return execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+        cwd: dir,
+        encoding: "utf-8",
+        env: GIT_ENV,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    }
+
+    function initGitRepo(dir: string): void {
+      git(dir, ["init"]);
+      git(dir, ["config", "user.email", "t@example.com"]);
+      git(dir, ["config", "user.name", "t"]);
+      git(dir, ["add", "-A"]);
+      git(dir, ["commit", "-m", "base", "--no-gpg-sign"]);
+    }
+
+    function runOverview(
+      dir: string,
+      options: { args?: string[]; env?: NodeJS.ProcessEnv } = {},
+    ): SpawnSyncReturns<string> {
+      return spawnSync(
+        TSX_BIN,
+        ["src/cli.ts", "overview", dir, "--json", ...(options.args ?? [])],
+        { cwd: process.cwd(), encoding: "utf-8", env: options.env ?? process.env },
+      );
+    }
+
     it("--force reparses even when a matching cache exists", () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-force-cache-"));
       try {
         fs.writeFileSync(path.join(dir, "index.ts"), "export const value = 1;\n");
-        const first = spawnSync(
-          "pnpm",
-          ["exec", "tsx", "src/cli.ts", "overview", dir, "--json"],
-          { cwd: process.cwd(), encoding: "utf-8" },
-        );
+        const first = runOverview(dir);
         expect(first.status).toBe(0);
 
-        const forced = spawnSync(
-          "pnpm",
-          ["exec", "tsx", "src/cli.ts", "overview", dir, "--json", "--force"],
-          { cwd: process.cwd(), encoding: "utf-8" },
-        );
+        const forced = runOverview(dir, { args: ["--force"] });
 
         expect(forced.status).toBe(0);
         expect(forced.stderr).toContain("Parsing");
         expect(forced.stderr).not.toContain("Using cached index");
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("invalidates cache when untracked TypeScript files appear without HEAD changing", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-untracked-cache-"));
+      try {
+        fs.writeFileSync(path.join(dir, "index.ts"), "export const value = 1;\n");
+        initGitRepo(dir);
+
+        const first = runOverview(dir);
+        expect(first.status).toBe(0);
+
+        const cached = runOverview(dir);
+        expect(cached.status).toBe(0);
+        expect(cached.stderr).toContain("Using cached index");
+
+        fs.writeFileSync(path.join(dir, "extra.ts"), "export const extra = 2;\n");
+        const changed = runOverview(dir);
+        expect(changed.status).toBe(0);
+        expect(changed.stderr).toContain("Parsing");
+        expect(changed.stderr).not.toContain("Using cached index");
+
+        const result = JSON.parse(changed.stdout) as { totalFiles: number };
+        expect(result.totalFiles).toBe(2);
       } finally {
         fs.rmSync(dir, { recursive: true, force: true });
       }
@@ -596,6 +684,7 @@ describe("CLI core commands (integration)", () => {
         expect(f).toHaveProperty("deadExports");
         expect(f).toHaveProperty("totalExports");
         expect(f.deadExports.length).toBeGreaterThan(0);
+        expect(f.totalExports).toBeGreaterThanOrEqual(f.deadExports.length);
       }
     });
 
@@ -604,6 +693,150 @@ describe("CLI core commands (integration)", () => {
       const result = computeDeadExports(codebaseGraph, undefined, 2);
 
       expect(result.files.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("computeOpportunities", () => {
+    it("returns ranked, evidence-bearing opportunities", () => {
+      const { codebaseGraph } = getFixturePipeline();
+      const result = computeOpportunities(codebaseGraph);
+
+      expect(typeof result.totalOpportunities).toBe("number");
+      expect(Array.isArray(result.opportunities)).toBe(true);
+      expect(typeof result.summary).toBe("string");
+
+      for (let index = 1; index < result.opportunities.length; index += 1) {
+        expect(result.opportunities[index - 1].score).toBeGreaterThanOrEqual(result.opportunities[index].score);
+      }
+
+      if (result.opportunities.length > 0) {
+        const first = result.opportunities[0];
+        expect(first).toHaveProperty("rank", 1);
+        expect(first).toHaveProperty("kind");
+        expect(first).toHaveProperty("target");
+        expect(first).toHaveProperty("priority");
+        expect(first).toHaveProperty("confidence");
+        expect(first.evidence.length).toBeGreaterThan(0);
+        expect(first.suggestedCommands.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("respects limit parameter", () => {
+      const { codebaseGraph } = getFixturePipeline();
+      const result = computeOpportunities(codebaseGraph, 2);
+
+      expect(result.opportunities.length).toBeLessThanOrEqual(2);
+    });
+
+    it("keeps short rankings diverse across targets", () => {
+      const graph: CodebaseGraph = {
+        nodes: [
+          { id: "src/a.ts", type: "file", path: "src/a.ts", label: "a.ts", loc: 400, module: "src/" },
+          { id: "src/b.ts", type: "file", path: "src/b.ts", label: "b.ts", loc: 20, module: "src/" },
+        ],
+        edges: [],
+        callEdges: [],
+        symbolNodes: [],
+        symbolMetrics: new Map(),
+        fileMetrics: new Map([
+          [
+            "src/a.ts",
+            opportunityMetrics({
+              fanIn: 50,
+              cyclomaticComplexity: 50,
+              blastRadius: 50,
+              deadExports: ["unusedA"],
+              totalExports: 1,
+              hasTests: false,
+            }),
+          ],
+          [
+            "src/b.ts",
+            opportunityMetrics({
+              fanIn: 1,
+              cyclomaticComplexity: 20,
+              blastRadius: 1,
+              hasTests: false,
+            }),
+          ],
+        ]),
+        moduleMetrics: new Map(),
+        groups: [],
+        processes: [],
+        clusters: [],
+        forceAnalysis: {
+          moduleCohesion: [],
+          tensionFiles: [],
+          bridgeFiles: [],
+          extractionCandidates: [],
+          shallowModules: [],
+          deepModules: [],
+          seamCandidates: [
+            {
+              target: "src/a.ts",
+              scope: "file",
+              exposedSymbols: 10,
+              fanIn: 20,
+              dependentModules: 5,
+              evidence: "a exports cross module boundaries",
+            },
+          ],
+          localityRisks: [
+            {
+              file: "src/a.ts",
+              kind: "ripple-zone",
+              tension: 1,
+              blastRadius: 50,
+              isBridge: false,
+              pulledByModuleCount: 5,
+              evidence: "a is pulled by many modules",
+            },
+          ],
+          summary: "",
+        },
+        stats: {
+          totalFiles: 2,
+          totalFunctions: 0,
+          totalDependencies: 0,
+          circularDeps: [],
+          analysisMode: "full-program",
+          callGraphPrecision: "type-resolved",
+          fullProgramFileLimit: 1500,
+        },
+      };
+
+      const result = computeOpportunities(graph, 3);
+
+      expect(result.opportunities.filter((opportunity) => opportunity.target === "src/a.ts")).toHaveLength(2);
+      expect(result.opportunities.some((opportunity) => opportunity.target === "src/b.ts")).toBe(true);
+    });
+  });
+
+  describe("opportunities CLI command", () => {
+    it("returns opportunities in JSON output", () => {
+      const stdout = execFileSync(
+        "pnpm",
+        ["exec", "tsx", "src/cli.ts", "opportunities", getFixtureSrcPath(), "--limit", "5", "--json", "--force"],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+      const parsed = JSON.parse(stdout) as Record<string, unknown>;
+
+      expect(parsed).toHaveProperty("totalOpportunities");
+      expect(parsed).toHaveProperty("opportunities");
+      expect(parsed).toHaveProperty("summary");
+      expect((parsed.opportunities as unknown[]).length).toBeLessThanOrEqual(5);
+    });
+
+    it("prints human-readable ranked opportunities", () => {
+      const stdout = execFileSync(
+        "pnpm",
+        ["exec", "tsx", "src/cli.ts", "opportunities", getFixtureSrcPath(), "--limit", "3", "--force"],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+
+      expect(stdout).toContain("Opportunities");
+      expect(stdout).toContain("Evidence:");
+      expect(stdout).toContain("Next:");
     });
   });
 
@@ -752,6 +985,9 @@ describe("CLI core commands (integration)", () => {
 
       const changes = computeChanges(codebaseGraph);
       expect("scope" in changes || "error" in changes).toBe(true);
+
+      const opportunities = computeOpportunities(codebaseGraph);
+      expect(typeof opportunities.totalOpportunities).toBe("number");
     });
   });
 });

--- a/tests/cli-mcp-stdio.e2e.test.ts
+++ b/tests/cli-mcp-stdio.e2e.test.ts
@@ -49,6 +49,7 @@ describe("CLI MCP stdio lifecycle (e2e)", () => {
       const tools = await client.listTools();
       const names = tools.tools.map((tool) => tool.name);
       expect(names).toContain("codebase_overview");
+      expect(names).toContain("find_opportunities");
       expect(names).toContain("check");
 
       const result = await client.callTool({ name: "codebase_overview", arguments: {} });

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -67,6 +67,10 @@ describe("Tool 2: file_context", () => {
     expect(m).toHaveProperty("fanIn");
     expect(m).toHaveProperty("churn");
     expect(m).toHaveProperty("blastRadius");
+    expect(m).toHaveProperty("totalExports");
+    expect(m).toHaveProperty("isPackageEntrypoint");
+    expect(m).toHaveProperty("packageEntrypointReason");
+    expect(m).toHaveProperty("isTestFile");
   });
 
   it("returns error for unknown file", async () => {
@@ -262,7 +266,26 @@ describe("Tool 7: find_dead_exports", () => {
   });
 });
 
-describe("Tool 8: get_groups", () => {
+describe("Tool 8: find_opportunities", () => {
+  it("returns ranked opportunities with evidence and next steps", async () => {
+    const r = await callTool("find_opportunities", { limit: 5 });
+    expect(r).toHaveProperty("totalOpportunities");
+    expect(r).toHaveProperty("opportunities");
+    expect(r).toHaveProperty("summary");
+    expect(r).toHaveProperty("nextSteps");
+    const opportunities = r.opportunities as Array<Record<string, unknown>>;
+    expect(opportunities.length).toBeLessThanOrEqual(5);
+    if (opportunities.length > 0) {
+      expect(opportunities[0]).toHaveProperty("rank");
+      expect(opportunities[0]).toHaveProperty("kind");
+      expect(opportunities[0]).toHaveProperty("target");
+      expect(opportunities[0]).toHaveProperty("evidence");
+      expect(opportunities[0]).toHaveProperty("suggestedCommands");
+    }
+  });
+});
+
+describe("Tool 9: get_groups", () => {
   it("returns ranked directory groups", async () => {
     const r = await callTool("get_groups");
     expect(r).toHaveProperty("groups");
@@ -278,7 +301,7 @@ describe("Tool 8: get_groups", () => {
   });
 });
 
-describe("Tool 9: symbol_context", () => {
+describe("Tool 10: symbol_context", () => {
   it("returns callers, callees, metrics for a known symbol", async () => {
     const symbolName = [...graph.symbolMetrics.values()][0].name;
     const r = await callTool("symbol_context", { name: symbolName });
@@ -302,7 +325,7 @@ describe("Tool 9: symbol_context", () => {
   });
 });
 
-describe("Tool 10: search", () => {
+describe("Tool 11: search", () => {
   it("returns ranked results for a valid query", async () => {
     const r = await callTool("search", { query: "auth" });
     expect(r).toHaveProperty("query", "auth");
@@ -323,14 +346,14 @@ describe("Tool 10: search", () => {
   });
 });
 
-describe("Tool 11: detect_changes", () => {
+describe("Tool 12: detect_changes", () => {
   it("handles git not available gracefully", async () => {
     const r = await callTool("detect_changes");
     expect(r).toHaveProperty("scope");
   });
 });
 
-describe("Tool 12: impact_analysis", () => {
+describe("Tool 13: impact_analysis", () => {
   it("returns depth-grouped impact for a known symbol", async () => {
     const r = await callTool("impact_analysis", { symbol: "UserService.getUserById" });
     expect(r).toHaveProperty("symbol");
@@ -350,7 +373,7 @@ describe("Tool 12: impact_analysis", () => {
   });
 });
 
-describe("Tool 13: rename_symbol", () => {
+describe("Tool 14: rename_symbol", () => {
   it("returns references for a dry-run rename", async () => {
     const r = await callTool("rename_symbol", { oldName: "getUserById", newName: "findUserById" });
     expect(r).toHaveProperty("dryRun", true);
@@ -359,7 +382,7 @@ describe("Tool 13: rename_symbol", () => {
   });
 });
 
-describe("Tool 14: get_processes", () => {
+describe("Tool 15: get_processes", () => {
   it("returns execution flow traces", async () => {
     const r = await callTool("get_processes");
     expect(r).toHaveProperty("processes");
@@ -387,7 +410,7 @@ describe("Tool 14: get_processes", () => {
   });
 });
 
-describe("Tool 15: get_clusters", () => {
+describe("Tool 16: get_clusters", () => {
   it("returns community-detected clusters", async () => {
     const r = await callTool("get_clusters");
     expect(r).toHaveProperty("clusters");
@@ -459,7 +482,8 @@ describe("MCP Resources", () => {
     expect(setup).toHaveProperty("project", "codebase-intelligence");
     expect(setup).toHaveProperty("indexedHead", "abc123-test");
     expect(setup).toHaveProperty("availableTools");
-    expect((setup.availableTools as string[]).length).toBe(16);
+    expect((setup.availableTools as string[]).length).toBe(17);
+    expect(setup.availableTools as string[]).toContain("find_opportunities");
     expect(setup.availableTools as string[]).toContain("check");
   });
 });

--- a/tests/package-entrypoints.test.ts
+++ b/tests/package-entrypoints.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { analyzeGraph } from "../src/analyzer/index.js";
+import { computeDeadExports, computeFileContext, computeOpportunities } from "../src/core/index.js";
+import { buildGraph } from "../src/graph/index.js";
+import { parseCodebase } from "../src/parser/index.js";
+import type { CodebaseGraph } from "../src/types/index.js";
+
+function analyzeTempCodebase(root: string): CodebaseGraph {
+  const parsed = parseCodebase(root);
+  return analyzeGraph(buildGraph(parsed), parsed);
+}
+
+describe("package public entrypoints", () => {
+  it("marks package exports, types, and bin source files as low-confidence dead exports", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ci-package-entrypoints-"));
+    try {
+      fs.mkdirSync(path.join(root, "src"), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          name: "fixture-package",
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+            "./feature": "./src/feature.ts",
+          },
+          types: "./dist/index.d.ts",
+          bin: {
+            fixture: "./dist/cli.js",
+          },
+        }),
+      );
+      fs.writeFileSync(path.join(root, "src", "index.ts"), "export const publicApi = 1;\n");
+      fs.writeFileSync(path.join(root, "src", "feature.ts"), "export const featureApi = 1;\n");
+      fs.writeFileSync(path.join(root, "src", "cli.ts"), "export function runCli() { return 1; }\n");
+      fs.writeFileSync(path.join(root, "src", "internal.ts"), "export const internalOnly = 1;\n");
+
+      const graph = analyzeTempCodebase(root);
+      const deadExports = computeDeadExports(graph, undefined, 10);
+
+      const byPath = new Map(deadExports.files.map((file) => [file.path, file]));
+      expect(byPath.get("src/index.ts")?.confidence).toBe("low");
+      expect(byPath.get("src/index.ts")?.isPackageEntrypoint).toBe(true);
+      expect(byPath.get("src/index.ts")?.packageEntrypointReason).toContain("package.json");
+      expect(byPath.get("src/feature.ts")?.confidence).toBe("low");
+      expect(byPath.get("src/cli.ts")?.confidence).toBe("low");
+      expect(byPath.get("src/internal.ts")?.confidence).toBe("high");
+
+      const context = computeFileContext(graph, "src/index.ts");
+      expect("error" in context).toBe(false);
+      if (!("error" in context)) {
+        expect(context.metrics.totalExports).toBe(1);
+        expect(context.metrics.isPackageEntrypoint).toBe(true);
+        expect(context.metrics.packageEntrypointReason).toContain("package.json");
+      }
+
+      const opportunities = computeOpportunities(graph, 10);
+      const publicApiOpportunity = opportunities.opportunities.find(
+        (opportunity) => opportunity.kind === "reduce-api-surface" && opportunity.target === "src/index.ts",
+      );
+      expect(publicApiOpportunity?.confidence).toBe("low");
+      expect(publicApiOpportunity?.title).toBe("Audit public API surface");
+      expect(publicApiOpportunity?.evidence).toContain("packageEntrypoint=true");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/phase6-red.test.ts
+++ b/tests/phase6-red.test.ts
@@ -19,7 +19,7 @@ describe("6.1 — CLI persistence commands", () => {
     const indexDir = path.join(tmpDir, ".code-visualizer");
 
     try {
-      exportGraph(codebaseGraph, indexDir, "test-head-hash");
+      exportGraph(codebaseGraph, indexDir, "test-head-hash", "test-cache-key");
 
       expect(fs.existsSync(path.join(indexDir, "graph.json"))).toBe(true);
       expect(fs.existsSync(path.join(indexDir, "meta.json"))).toBe(true);
@@ -27,9 +27,13 @@ describe("6.1 — CLI persistence commands", () => {
       const meta = JSON.parse(fs.readFileSync(path.join(indexDir, "meta.json"), "utf-8")) as {
         headHash: string;
         timestamp: string;
+        version: number;
+        cacheKey: string;
       };
       expect(meta.headHash).toBe("test-head-hash");
       expect(meta.timestamp).toBeDefined();
+      expect(meta.version).toBe(3);
+      expect(meta.cacheKey).toBe("test-cache-key");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -43,13 +47,14 @@ describe("6.1 — CLI persistence commands", () => {
     const indexDir = path.join(tmpDir, ".code-visualizer");
 
     try {
-      exportGraph(codebaseGraph, indexDir, "status-hash-abc");
+      exportGraph(codebaseGraph, indexDir, "status-hash-abc", "status-cache-key");
       const result = importGraph(indexDir);
 
       expect(result).not.toBeNull();
       if (!result) return;
 
       expect(result.headHash).toBe("status-hash-abc");
+      expect(result.cacheKey).toBe("status-cache-key");
       expect(result.graph.nodes.length).toBe(codebaseGraph.nodes.length);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -121,9 +126,7 @@ describe("6.2 — per-symbol PageRank/betweenness", () => {
   it("high fan-in symbols have higher pageRank", () => {
     const { codebaseGraph } = getFixturePipeline();
 
-    const withRank = [...codebaseGraph.symbolMetrics.values()]
-      .filter((m) => m.pageRank !== undefined)
-      .sort((a, b) => b.pageRank - a.pageRank);
+    const withRank = [...codebaseGraph.symbolMetrics.values()].sort((a, b) => b.pageRank - a.pageRank);
 
     expect(withRank.length).toBeGreaterThan(0);
 

--- a/tools/verify-cli-real-codebases.mjs
+++ b/tools/verify-cli-real-codebases.mjs
@@ -6,6 +6,26 @@ import { spawnSync } from "node:child_process";
 
 const root = process.cwd();
 const cli = path.join(root, "dist", "cli.js");
+const expectedVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf-8")).version;
+const profile = process.env.CBI_REAL_PROFILE ?? "default";
+const timeoutMs = Number.parseInt(
+  process.env.CBI_REAL_TIMEOUT_MS ?? (profile === "heavy" ? "180000" : "60000"),
+  10,
+);
+const maxBufferBytes = Number.parseInt(process.env.CBI_REAL_MAX_BUFFER ?? String(64 * 1024 * 1024), 10);
+const parsedToTrackedTolerance = 1.25;
+const parsedToTrackedSlack = 20;
+const minLargeRepoDependencyDensity = 0.05;
+const largeRepoFileThreshold = 300;
+const bannedPathSegments = new Set([
+  ".code-visualizer",
+  ".next",
+  "dist",
+  "coverage",
+  ".turbo",
+  ".cache",
+  ".worktrees",
+]);
 
 const defaultTargets = [
   { name: "codebase-intelligence", path: root, file: "src/install/index.ts", symbol: "upsertManagedBlock" },
@@ -23,6 +43,33 @@ const defaultTargets = [
   },
 ];
 
+const heavyProfileTargets = [
+  {
+    name: "heavy-harness",
+    path: "/home/ubuntu/harness",
+    file: "harnesses/cli/src/cli-args/list-models.ts",
+    symbol: "listModels",
+    minFiles: 800,
+    minDependencies: 500,
+  },
+  {
+    name: "heavy-ui",
+    path: "/home/ubuntu/ui",
+    file: "",
+    symbol: "",
+    minFiles: 1500,
+    minDependencies: 1000,
+  },
+  {
+    name: "heavy-songtrivia",
+    path: "/home/ubuntu/anthm/songtrivia",
+    file: "",
+    symbol: "",
+    minFiles: 2500,
+    minDependencies: 2500,
+  },
+];
+
 const extraTargets = (process.env.CBI_REAL_TARGETS ?? "")
   .split(",")
   .map((value) => value.trim())
@@ -34,7 +81,18 @@ const extraTargets = (process.env.CBI_REAL_TARGETS ?? "")
     symbol: "",
   }));
 
-const targets = [...defaultTargets, ...extraTargets].filter((target) => fs.existsSync(target.path));
+const profileTargets = profile === "heavy" ? heavyProfileTargets : [];
+if (profile !== "default" && profile !== "heavy") {
+  console.error(`Unknown CBI_REAL_PROFILE=${profile}; expected default or heavy`);
+  process.exit(2);
+}
+
+const shouldDiscoverHome = process.env.CBI_REAL_DISCOVER_HOME === "1" || profile === "heavy";
+const discoveredTargets = shouldDiscoverHome
+  ? discoverHomeTargets(process.env.CBI_REAL_HOME ?? "/home/ubuntu", profile === "heavy" ? largeRepoFileThreshold : 1)
+  : [];
+
+const targets = uniqueTargets([...defaultTargets, ...profileTargets, ...extraTargets, ...discoveredTargets]);
 
 let pass = 0;
 let fail = 0;
@@ -43,7 +101,8 @@ function run(args, okCodes = [0]) {
   const result = spawnSync("node", [cli, ...args], {
     encoding: "utf-8",
     cwd: root,
-    timeout: 30_000,
+    timeout: timeoutMs,
+    maxBuffer: maxBufferBytes,
   });
   if (result.error) throw result.error;
   if (!okCodes.includes(result.status)) {
@@ -55,7 +114,9 @@ function run(args, okCodes = [0]) {
 }
 
 function json(args, okCodes = [0]) {
-  return JSON.parse(run([...args, "--json"], okCodes).stdout);
+  const result = JSON.parse(run([...args, "--json"], okCodes).stdout);
+  assertNoBannedPaths(result, args.join(" "));
+  return result;
 }
 
 function record(name, fn) {
@@ -77,6 +138,173 @@ function arrayAt(value, keys) {
   return [];
 }
 
+function uniqueTargets(candidates) {
+  const seen = new Set();
+  const targets = [];
+
+  for (const target of candidates) {
+    if (!fs.existsSync(target.path)) continue;
+    const realPath = fs.realpathSync(target.path);
+    if (seen.has(realPath)) continue;
+    seen.add(realPath);
+    targets.push(target);
+  }
+
+  return targets;
+}
+
+function discoverHomeTargets(homeDir, minTrackedFiles) {
+  const repos = [];
+  const maxDepth = Number.parseInt(process.env.CBI_REAL_DISCOVER_DEPTH ?? "5", 10);
+  const limit = Number.parseInt(process.env.CBI_REAL_DISCOVER_LIMIT ?? "6", 10);
+  const queue = [{ dir: homeDir, depth: 0 }];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || current.depth > maxDepth || !fs.existsSync(current.dir)) continue;
+
+    if (fs.existsSync(path.join(current.dir, ".git"))) {
+      const trackedFiles = trackedTypeScriptCount(current.dir);
+      if (trackedFiles >= minTrackedFiles) {
+        repos.push({ path: current.dir, trackedFiles });
+      }
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(current.dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (shouldSkipDiscoveryDir(entry.name)) continue;
+      queue.push({ dir: path.join(current.dir, entry.name), depth: current.depth + 1 });
+    }
+  }
+
+  return repos
+    .sort((left, right) => right.trackedFiles - left.trackedFiles)
+    .slice(0, limit)
+    .map((repo, index) => ({
+      name: `home-${index + 1}-${path.basename(repo.path)}`,
+      path: repo.path,
+      file: "",
+      symbol: "",
+    }));
+}
+
+function shouldSkipDiscoveryDir(name) {
+  return name === ".git"
+    || name === "node_modules"
+    || name === ".code-visualizer"
+    || name === ".next"
+    || name === "dist"
+    || name === "coverage"
+    || name === ".turbo"
+    || name === ".cache"
+    || name === ".worktrees"
+    || name === ".claude";
+}
+
+function trackedTypeScriptCount(targetPath) {
+  const target = path.resolve(targetPath);
+  const rootResult = spawnSync("git", ["-C", target, "rev-parse", "--show-toplevel"], {
+    encoding: "utf-8",
+  });
+  if (rootResult.status !== 0) return 0;
+
+  const repoRoot = rootResult.stdout.trim();
+  const filesResult = spawnSync("git", ["-C", repoRoot, "ls-files", "--", "*.ts", "*.tsx"], {
+    encoding: "utf-8",
+  });
+  if (filesResult.status !== 0) return 0;
+
+  return filesResult.stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((file) => path.resolve(repoRoot, file))
+    .filter((file) => file.startsWith(`${target}${path.sep}`) || file === target)
+    .filter((file) => !file.endsWith(".d.ts"))
+    .length;
+}
+
+function overviewFileCount(overview) {
+  const files = overview.files ?? overview.fileCount ?? overview.totalFiles;
+  if (typeof files !== "number") throw new Error("missing file count");
+  return files;
+}
+
+function assertParsedToTrackedRatio(target, parsedFiles) {
+  const trackedFiles = trackedTypeScriptCount(target.path);
+  if (trackedFiles === 0) return;
+
+  const allowed = Math.ceil(trackedFiles * parsedToTrackedTolerance + parsedToTrackedSlack);
+  if (parsedFiles > allowed) {
+    throw new Error(
+      `parsed ${parsedFiles} files but git tracks ${trackedFiles}; likely generated/worktree pollution`,
+    );
+  }
+}
+
+function assertDependencyDensity(overview) {
+  const files = overviewFileCount(overview);
+  const dependencies = overview.totalDependencies;
+  if (files < largeRepoFileThreshold || typeof dependencies !== "number") return;
+
+  const minDependencies = Math.floor(files * minLargeRepoDependencyDensity);
+  if (dependencies < minDependencies) {
+    throw new Error(
+      `only ${dependencies} dependencies for ${files} files; likely unresolved workspace imports`,
+    );
+  }
+}
+
+function assertTargetThresholds(target, overview) {
+  const files = overviewFileCount(overview);
+  const dependencies = overview.totalDependencies;
+
+  if (typeof target.minFiles === "number" && files < target.minFiles) {
+    throw new Error(`expected at least ${target.minFiles} files for ${target.name}, got ${files}`);
+  }
+
+  if (typeof target.minDependencies === "number" && typeof dependencies === "number" && dependencies < target.minDependencies) {
+    throw new Error(`expected at least ${target.minDependencies} dependencies for ${target.name}, got ${dependencies}`);
+  }
+}
+
+function assertNoBannedPaths(value, location) {
+  const violation = findBannedPath(value);
+  if (violation) {
+    throw new Error(`banned generated/worktree path in ${location}: ${violation}`);
+  }
+}
+
+function findBannedPath(value) {
+  if (typeof value === "string") {
+    const normalized = value.replaceAll("\\", "/");
+    if (normalized.includes("package.json:")) return "";
+    const segments = normalized.split("/");
+    if (segments.includes(".claude") && segments.includes("worktrees")) return value;
+    for (const segment of segments) {
+      if (bannedPathSegments.has(segment)) return value;
+    }
+    return "";
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const result = findBannedPath(item);
+      if (result) return result;
+    }
+    return "";
+  }
+
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) {
+      const result = findBannedPath(item);
+      if (result) return result;
+    }
+  }
+
+  return "";
+}
+
 function discoverFileAndSymbol(target) {
   if (target.file && target.symbol) return target;
   const hotspots = json(["hotspots", target.path, "--metric", "tension", "--limit", "12"]);
@@ -92,7 +320,7 @@ function discoverFileAndSymbol(target) {
 
 record("version", () => {
   const version = run(["--version"]).stdout.trim();
-  if (!/^2\.\d+\.\d+/.test(version)) throw new Error(`unexpected version ${version}`);
+  if (version !== expectedVersion) throw new Error(`expected version ${expectedVersion}, got ${version}`);
   return version;
 });
 
@@ -101,8 +329,10 @@ for (const inputTarget of targets) {
 
   record(`${target.name}: overview`, () => {
     const overview = json(["overview", target.path]);
-    const files = overview.files ?? overview.fileCount ?? overview.totalFiles;
-    if (typeof files !== "number") throw new Error("missing file count");
+    const files = overviewFileCount(overview);
+    assertParsedToTrackedRatio(target, files);
+    assertDependencyDensity(overview);
+    assertTargetThresholds(target, overview);
     return `${files} files`;
   });
 
@@ -141,7 +371,7 @@ for (const inputTarget of targets) {
     return `${result.totalAffected} affected`;
   });
 
-  for (const command of ["modules", "forces", "dead-exports", "groups", "processes", "clusters"]) {
+  for (const command of ["modules", "forces", "dead-exports", "opportunities", "groups", "processes", "clusters"]) {
     record(`${target.name}: ${command}`, () => {
       const result = json([command, target.path]);
       if (!result || typeof result !== "object") throw new Error("invalid JSON object");


### PR DESCRIPTION
## Summary
- add ranked code-quality/refactoring opportunities across CLI + MCP
- harden parser/cache behavior for generated dirs, dirty/untracked worktrees, monorepo imports, and large-repo AST-only mode
- expose analysis precision metadata and package-entrypoint confidence in CLI/MCP/docs
- expand default + heavy real-repo verification against large /home/ubuntu repos

## Review + Fix Loop
- code-review mode: Production
- codebase-intelligence gate: ran overview, changes, hotspots, dead-exports, dependents, impact
- react-doctor: not applicable, no React package/UI diff
- blocker fixed during review: file_context now returns new FileMetrics fields promised by docs
- machine artifact emitted locally: /tmp/code-review-artifact.json

## Validation
- pnpm lint
- pnpm exec tsc --noEmit --project tsconfig.json
- pnpm build
- pnpm test (26 files, 416 tests)
- pnpm verify:cli-real (56/56)
- pnpm verify:cli-real:heavy (158/158)
- git diff --check
