### PR TITLE
feat(analysis): add type shape facts to symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 - **Cache migration facts** in JSON (`cacheDir`, `legacyCacheDir`, `migrated`, `gitignoreUpdated`, `warnings[]`)
 - **11 architectural metrics** — PageRank, betweenness, coupling, cohesion, tension, churn, complexity, blast radius, dead exports, test coverage, escape velocity
 - **Symbol-level analysis** — callers/callees, symbol importance, impact blast radius
-- **BM25 search** — ranked keyword search across files and symbols
+- **BM25 search** — ranked keyword search across files, symbols, and type/shape facts
 - **Process tracing** — detect entry points and execution flows through the call graph
 - **Community detection** — Louvain clustering for natural file groupings
 - **Agent adoption** — `init` writes per-agent instruction files + installs a skill so AI agents query CI before grep/read
@@ -96,7 +96,7 @@ codebase-intelligence <command> <path> [options]
 | `overview` | High-level codebase snapshot |
 | `hotspots` | Rank files by metric (coupling, churn, complexity, blast radius, coverage, etc.) |
 | `file` | Full context for one file |
-| `search` | BM25 keyword search |
+| `search` | BM25 keyword and shape search |
 | `changes` | Git diff analysis with risk metrics |
 | `dependents` | File-level blast radius |
 | `modules` | Module architecture + cross-dependencies |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ CLI (commander)
   |
   v
 Parser (TS Compiler API)
-  | extracts: files, exports, imports, LOC, complexity, churn, test mapping
+  | extracts: files, exports, symbols, type facts, imports, LOC, complexity, churn, test mapping
   v
 Graph Builder (graphology)
   | creates: nodes (file + function), edges (imports with symbols/weights)
@@ -34,8 +34,10 @@ MCP (stdio)                    CLI (terminal/CI)
 ```
 src/
   types/index.ts       <- ALL interfaces (single source of truth)
-  parser/index.ts      <- TS AST extraction + git churn + test detection
-  graph/index.ts       <- graphology graph + circular dep detection
+  parser/index.ts      <- Parse orchestration + imports/exports/call sites + git churn/test detection
+  parser/type-facts.ts <- Type signatures, parameters, consumed/produced shape facts
+  parser/symbols.ts    <- Symbol inventory + symbol complexity
+  graph/index.ts       <- graphology graph + symbol/type graph + circular dep detection
   analyzer/index.ts    <- All metric computation
   graph-loader/index.ts <- Shared parse/build/analyze/cache pipeline + progress events
   core/index.ts        <- Shared result computation (MCP + CLI)
@@ -65,7 +67,7 @@ loadCodebaseGraph(rootDir)
   -> otherwise emits progress events through parse/build/analyze/cache
 
 parseCodebase(rootDir)
-  -> ParsedFile[] (with churn, complexity, test mapping)
+  -> ParsedFile[] (with churn, complexity, test mapping, symbol type facts)
 
 buildGraph(parsedFiles)
   -> BuiltGraph { graph: Graph, nodes: GraphNode[], edges: GraphEdge[] }
@@ -88,6 +90,7 @@ runOperation(operation, codebaseGraph, input, context)
 
 - **Dual interface**: MCP stdio for LLM agents, CLI subcommands for humans/CI. Both consume `src/core/`.
 - **Operation registry foundation**: Analysis operations now have typed descriptors in `src/operations/` with operation names, CLI command names, MCP tool names, input schemas, discriminated run results, and result-object text formatters. MCP tool registration and CLI command execution consume those descriptors; CLI JSON remains raw result data plus cache facts.
+- **Type/Shape facts**: Full-program parsing stores compact parameter/return/type-parameter facts on parsed symbols. `file`, `symbol`, and `search` JSON expose those facts additively; search indexes consumed/produced shape tokens so agents can ask which symbols touch a shape without a new command.
 - **Shared graph-load pipeline**: CLI commands and MCP stdio startup both use `src/graph-loader/` for path checks, legacy cache migration, cache reuse, parse/build/analyze, optional persistence, and stderr progress events.
 - **graphology**: In-memory graph with O(1) neighbor lookup. PageRank and betweenness computed via graphology-metrics.
 - **Batch git churn**: Single `git log --all --name-only` call, parsed for all files. Avoids O(n) subprocess spawning.
@@ -102,8 +105,8 @@ runOperation(operation, codebaseGraph, input, context)
 
 Vertical slice through all layers:
 
-1. **types/index.ts** — Add field to `FileMetrics` (and `ParsedFile`/`ParsedExport` if extracted at parse time)
-2. **parser/index.ts** — Extract raw data from AST or external source (git, filesystem)
+1. **types/index.ts** — Add field to `FileMetrics`, `ParsedFile` / `ParsedExport`, or `SymbolTypeFacts` if extracted at parse time
+2. **parser/index.ts / parser/type-facts.ts / parser/symbols.ts** — Extract raw data from AST or external source (git, filesystem)
 3. **analyzer/index.ts** — Compute derived metric, store in `fileMetrics` map
 4. **operations/index.ts / operations/formatters.ts** — Add or update the operation descriptor, input schema, text formatter, and CLI/MCP mapping
 5. **mcp/index.ts / cli.ts** — Expose via existing adapter or new command/tool

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ codebase-intelligence file <path> <file> [--json] [--force]
 
 `<file>` is relative to the codebase root (e.g., `parser/index.ts`).
 
-**Output:** LOC, exports, imports, dependents, all FileMetrics. Error: prints top 3 similar path suggestions.
+**Output:** LOC, exports (including additive `typeFacts` when known), imports, dependents, all FileMetrics. Error: prints top 3 similar path suggestions.
 
 ### search
 
@@ -44,7 +44,7 @@ BM25 keyword search.
 codebase-intelligence search <path> <query> [--limit <n>] [--json] [--force]
 ```
 
-**Output:** Ranked results grouped by file, with symbol name, type, LOC, and relevance score.
+**Output:** Ranked results grouped by file, with symbol name, type, LOC, relevance score, and additive `typeFacts` when known. Type facts are indexed, so shape names like `CreateUserInput` find producers/consumers.
 
 ### changes
 
@@ -124,7 +124,7 @@ Function/class context with callers and callees.
 codebase-intelligence symbol <path> <name> [--json] [--force]
 ```
 
-**Output:** symbol metadata, fan-in/out, PageRank, betweenness, callers, callees.
+**Output:** symbol metadata, additive `typeFacts` when known, fan-in/out, PageRank, betweenness, callers, callees.
 
 ### impact
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -10,6 +10,7 @@ ParsedFile {
   relativePath: string    // Relative to root (used as graph node ID)
   loc: number             // Lines of code
   exports: ParsedExport[] // Named exports
+  symbols?: ParsedSymbol[] // Exported and local symbols with type facts
   imports: ParsedImport[] // Relative imports (external skipped)
   churn: number           // Git commit count (0 if non-git)
   isTestFile: boolean     // Matches *.test.ts / *.spec.ts / __tests__/
@@ -22,6 +23,21 @@ ParsedExport {
   loc: number             // Lines of code for this export
   isDefault: boolean
   complexity: number      // Cyclomatic complexity (branch count, min 1)
+  typeFacts?: SymbolTypeFacts
+}
+
+ParsedSymbol extends ParsedExport {
+  isExported: boolean     // false for local class methods / helper symbols
+}
+
+SymbolTypeFacts {
+  signature: string       // Compact display signature
+  parameters: Array<{ name: string, type: string, optional: boolean, rest: boolean }>
+  returnType?: string
+  typeParameters: Array<{ name: string, constraint?: string, default?: string }>
+  consumes: string[]      // Shape/type names read by parameters
+  produces: string[]      // Shape/type names returned or declared
+  confidence: "resolved" | "syntax"
 }
 
 ParsedImport {
@@ -37,7 +53,7 @@ ParsedImport {
 ```typescript
 GraphNode {
   id: string              // = relativePath for files, parentFile+name for functions
-  type: "file" | "function"
+  type: "file" | "function" | "class"
   path: string            // Display path
   label: string           // File basename or function name
   loc: number
@@ -51,6 +67,18 @@ GraphEdge {
   symbols: string[]       // What's imported
   isTypeOnly: boolean     // Type-only import (no runtime dep)
   weight: number          // Edge weight (default 1)
+}
+
+SymbolNode {
+  id: string              // file::symbol
+  name: string
+  type: ParsedExport["type"]
+  file: string
+  loc: number
+  isDefault: boolean
+  complexity: number
+  isExported?: boolean
+  typeFacts?: SymbolTypeFacts
 }
 ```
 
@@ -102,6 +130,9 @@ ModuleMetrics {
 CodebaseGraph {
   nodes: GraphNode[]
   edges: GraphEdge[]
+  callEdges: CallEdge[]
+  symbolNodes: SymbolNode[]
+  symbolMetrics: Map<string, SymbolMetrics>
   fileMetrics: Map<string, FileMetrics>
   moduleMetrics: Map<string, ModuleMetrics>
   forceAnalysis: ForceAnalysis

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -19,7 +19,7 @@ High-level summary of the entire codebase.
 Detailed context for a single file.
 
 **Input:** `{ filePath: string }` (relative path)
-**Returns:** path, loc, exports, imports (with symbols, isTypeOnly, weight), dependents (with symbols, isTypeOnly, weight), metrics (all FileMetrics including churn, complexity, blastRadius, deadExports, totalExports, package-entrypoint metadata, hasTests, testFile)
+**Returns:** path, loc, exports (with additive `typeFacts` when known), imports (with symbols, isTypeOnly, weight), dependents (with symbols, isTypeOnly, weight), metrics (all FileMetrics including churn, complexity, blastRadius, deadExports, totalExports, package-entrypoint metadata, hasTests, testFile)
 
 **Path normalization:** Backslashes are normalized to forward slashes. The exact graph path is tried first; if not found, common prefixes (`src/`, `lib/`, `app/`) are stripped once from the leading position and retried. If the file is not found, the error includes up to 3 suggested similar paths.
 
@@ -104,7 +104,7 @@ Top-level directory groups with aggregate metrics.
 Callers, callees, and importance metrics for a function, class, or method.
 
 **Input:** `{ name: string }` (e.g., 'AuthService', 'getUserById')
-**Returns:** name, file, type, loc, isDefault, complexity, fanIn, fanOut, pageRank, betweenness, callers (with confidence), callees (with confidence)
+**Returns:** name, file, type, loc, isDefault, complexity, additive `typeFacts` when known, fanIn, fanOut, pageRank, betweenness, callers (with confidence), callees (with confidence)
 
 **Use when:** "Who calls X?" "Trace this function." "What depends on this symbol?"
 **Not for:** Text search (use search) or file-level dependencies (use get_dependents).
@@ -114,7 +114,7 @@ Callers, callees, and importance metrics for a function, class, or method.
 Search files and symbols by keyword.
 
 **Input:** `{ query: string, limit?: number }` (default limit: 20)
-**Returns:** ranked results grouped by file with symbol names, types, LOC, and relevance scores. Suggests alternatives on empty results.
+**Returns:** ranked results grouped by file with symbol names, types, LOC, relevance scores, and additive `typeFacts` when known. Type facts are indexed, so shape names can find symbols that consume or produce that shape. Suggests alternatives on empty results.
 
 **Use when:** "Find files related to auth." "Where is getUserById defined?"
 **Not for:** Structured call graph queries (use symbol_context).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -40,8 +40,10 @@ MCP (stdio) + CLI
 ```
 src/
   types/index.ts       <- ALL interfaces (single source of truth)
-  parser/index.ts      <- TS AST extraction + git churn + test detection
-  graph/index.ts       <- graphology graph + circular dep detection
+  parser/index.ts      <- Parse orchestration + imports/exports/call sites + git churn/test detection
+  parser/type-facts.ts <- Type signatures, parameters, consumed/produced shape facts
+  parser/symbols.ts    <- Symbol inventory + symbol complexity
+  graph/index.ts       <- graphology graph + symbol/type graph + circular dep detection
   analyzer/index.ts    <- All metric computation
   graph-loader/index.ts <- Shared parse/build/analyze/cache pipeline + progress events
   core/index.ts        <- Shared result computation (MCP + CLI)
@@ -109,6 +111,7 @@ ParsedFile {
   relativePath: string    // Relative to root (used as graph node ID)
   loc: number             // Lines of code
   exports: ParsedExport[] // Named exports
+  symbols?: ParsedSymbol[] // Exported/local symbols with type facts
   imports: ParsedImport[] // Relative imports (external skipped)
   churn: number           // Git commit count (0 if non-git)
   isTestFile: boolean     // Matches *.test.ts / *.spec.ts / __tests__/
@@ -121,6 +124,21 @@ ParsedExport {
   loc: number             // Lines of code for this export
   isDefault: boolean
   complexity: number      // Cyclomatic complexity (branch count, min 1)
+  typeFacts?: SymbolTypeFacts
+}
+
+ParsedSymbol extends ParsedExport {
+  isExported: boolean
+}
+
+SymbolTypeFacts {
+  signature: string
+  parameters: Array<{ name: string, type: string, optional: boolean, rest: boolean }>
+  returnType?: string
+  typeParameters: Array<{ name: string, constraint?: string, default?: string }>
+  consumes: string[]
+  produces: string[]
+  confidence: "resolved" | "syntax"
 }
 
 ParsedImport {
@@ -271,10 +289,10 @@ Rank code quality and refactoring opportunities. Input: `{ limit?: number }`. Re
 Top-level directory groups. Input: `{}`. Returns: groups with rank, files, loc, importance, coupling.
 
 ## 10. symbol_context
-Function/class context. Input: `{ name: string }`. Returns: callers, callees, metrics.
+Function/class/method context. Input: `{ name: string }`. Returns: callers, callees, metrics, additive typeFacts when known.
 
 ## 11. search
-Keyword search (BM25). Input: `{ query: string, limit?: number }`. Returns: ranked files + symbols.
+Keyword/search shape facts (BM25). Input: `{ query: string, limit?: number }`. Returns: ranked files + symbols with additive typeFacts when known.
 
 ## 12. detect_changes
 Git diff analysis. Input: `{ scope?: "staged" | "unstaged" | "all" }`. Returns: changed files, affected files, risk metrics.
@@ -347,7 +365,7 @@ Detailed file context: exports, imports, dependents, all metrics.
 ```bash
 codebase-intelligence search <path> <query> [--limit <n>] [--json] [--force]
 ```
-BM25 keyword search across files and symbols.
+BM25 keyword search across files, symbols, and type/shape facts.
 
 ### changes
 ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -22,7 +22,7 @@ CLI mode (humans/CI) — 18 commands (16 analysis with MCP parity + `check` + `i
 codebase-intelligence overview ./src
 codebase-intelligence hotspots ./src --metric coupling
 codebase-intelligence file ./src parser/index.ts
-codebase-intelligence search ./src "auth"
+codebase-intelligence search ./src "auth"             # keyword or type/shape query
 codebase-intelligence changes ./src --json
 codebase-intelligence dependents ./src types.ts --depth 3
 codebase-intelligence modules ./src

--- a/roadmap.md
+++ b/roadmap.md
@@ -287,10 +287,16 @@ Collapse CLI + MCP operation duplication into one descriptor registry before add
 
 Capture resolved parameter and return types per symbol.
 
-**To do:**
+**Foundation slice:**
 
 - Store compact type signatures on parsed symbols.
-- Support "which functions produce/consume shape X" queries.
+- Carry type facts into graph `SymbolNode` data.
+- Expose additive `typeFacts` in `file`, `symbol`, and `search` JSON.
+- Index consumed/produced type names in search so shape queries find producer/consumer symbols.
+- Add CH-P1-03 coverage for aliases, generics, default exports, unresolved types, file/symbol/search JSON, CLI, and MCP parity.
+
+**Remaining:**
+
 - Unlock type-aware dead code and Highways H2 shape grouping.
 - Use type facts for synthesized highway signatures.
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
-import type { AnalysisMode, CallGraphPrecision, CodebaseGraph } from "../types/index.js";
+import type { AnalysisMode, CallGraphPrecision, CodebaseGraph, SymbolTypeFacts } from "../types/index.js";
 import { createSearchIndex, search, getSuggestions } from "../search/index.js";
 import type { SearchIndex } from "../search/index.js";
 import { impactAnalysis, renameSymbol } from "../impact/index.js";
@@ -147,7 +147,7 @@ export function computeOverview(graph: CodebaseGraph): OverviewResult {
 export interface FileContextResult {
   path: string;
   loc: number;
-  exports: Array<{ name: string; type: string; loc: number }>;
+  exports: Array<{ name: string; type: string; loc: number; typeFacts?: SymbolTypeFacts }>;
   imports: Array<{ from: string; symbols: string[]; isTypeOnly: boolean; weight: number }>;
   dependents: Array<{ path: string; symbols: string[]; isTypeOnly: boolean; weight: number }>;
   metrics: {
@@ -191,9 +191,9 @@ export function computeFileContext(
 
   const nodeById = buildNodeById(graph);
   const node = nodeById.get(filePath);
-  const fileExports = graph.nodes
-    .filter((n) => n.parentFile === filePath)
-    .map((n) => ({ name: n.label, type: n.type, loc: n.loc }));
+  const fileExports = graph.symbolNodes
+    .filter((symbol) => symbol.file === filePath && symbol.isExported !== false)
+    .map((symbol) => ({ name: symbol.name, type: symbol.type, loc: symbol.loc, typeFacts: symbol.typeFacts }));
 
   const imports = graph.edges
     .filter((e) => e.source === filePath)
@@ -352,7 +352,7 @@ export function computeHotspots(
 export interface SearchResultEntry {
   file: string;
   score: number;
-  symbols: Array<{ name: string; type: string; loc: number; relevance: number }>;
+  symbols: Array<{ name: string; type: string; loc: number; relevance: number; typeFacts?: SymbolTypeFacts }>;
 }
 
 export interface SearchResult {
@@ -382,6 +382,7 @@ export function computeSearch(
       type: s.type,
       loc: s.loc,
       relevance: s.score,
+      typeFacts: s.typeFacts,
     })),
   }));
 
@@ -1036,6 +1037,7 @@ export function computeGroups(graph: CodebaseGraph): GroupsResult {
 export interface SymbolContextResult {
   name: string; file: string; type: string; loc: number;
   isDefault: boolean; complexity: number;
+  typeFacts?: SymbolTypeFacts;
   fanIn: number; fanOut: number; pageRank: number; betweenness: number;
   callers: Array<{ symbol: string; file: string; confidence: string }>;
   callees: Array<{ symbol: string; file: string; confidence: string }>;
@@ -1069,6 +1071,7 @@ export function computeSymbolContext(
     name: sym.name, file: sym.file,
     type: symNode?.type ?? "function", loc: symNode?.loc ?? 0,
     isDefault: symNode?.isDefault ?? false, complexity: symNode?.complexity ?? 0,
+    typeFacts: symNode?.typeFacts,
     fanIn: sym.fanIn, fanOut: sym.fanOut,
     pageRank: Math.round(sym.pageRank * 10000) / 10000,
     betweenness: Math.round(sym.betweenness * 10000) / 10000,

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,6 +1,6 @@
 import Graph from "graphology";
 import path from "path";
-import type { ParsedFile, GraphNode, GraphEdge, CallEdge, SymbolNode } from "../types/index.js";
+import type { ParsedFile, GraphNode, GraphEdge, CallEdge, SymbolNode, ParsedSymbol } from "../types/index.js";
 
 export interface BuiltGraph {
   graph: Graph;
@@ -124,23 +124,26 @@ export function buildGraph(files: ParsedFile[]): BuiltGraph {
   const symbolNodes: SymbolNode[] = [];
   const callGraphNodeIds = new Set<string>();
 
-  // Build symbol nodes from all exported symbols (functions, classes, interfaces, types, enums)
+  // Build symbol nodes from parsed symbols when available, including local methods.
   const symbolTypes = new Set(["function", "class", "interface", "type", "enum"]);
   for (const file of files) {
-    for (const exp of file.exports) {
-      if (symbolTypes.has(exp.type)) {
-        const symbolId = `${file.relativePath}::${exp.name}`;
+    const parsedSymbols = symbolsForGraph(file);
+    for (const symbol of parsedSymbols) {
+      if (symbolTypes.has(symbol.type)) {
+        const symbolId = `${file.relativePath}::${symbol.name}`;
         symbolNodes.push({
           id: symbolId,
-          name: exp.name,
-          type: exp.type,
+          name: symbol.name,
+          type: symbol.type,
           file: file.relativePath,
-          loc: exp.loc,
-          isDefault: exp.isDefault,
-          complexity: exp.complexity,
+          loc: symbol.loc,
+          isDefault: symbol.isDefault,
+          complexity: symbol.complexity,
+          isExported: symbol.isExported,
+          typeFacts: symbol.typeFacts,
         });
         if (!callGraphNodeIds.has(symbolId)) {
-          callGraph.addNode(symbolId, { name: exp.name, type: exp.type, file: file.relativePath });
+          callGraph.addNode(symbolId, { name: symbol.name, type: symbol.type, file: file.relativePath });
           callGraphNodeIds.add(symbolId);
         }
       }
@@ -170,6 +173,7 @@ export function buildGraph(files: ParsedFile[]): BuiltGraph {
           loc: 0,
           isDefault: false,
           complexity: 0,
+          isExported: false,
         });
         symbolNodeIds.add(sourceId);
       }
@@ -184,6 +188,7 @@ export function buildGraph(files: ParsedFile[]): BuiltGraph {
           loc: 0,
           isDefault: false,
           complexity: 0,
+          isExported: false,
         });
         symbolNodeIds.add(targetId);
       }
@@ -211,6 +216,20 @@ export function buildGraph(files: ParsedFile[]): BuiltGraph {
   }
 
   return { graph, callGraph, nodes, edges, callEdges, symbolNodes };
+}
+
+function symbolsForGraph(file: ParsedFile): ParsedSymbol[] {
+  const symbols = [...(file.symbols ?? [])];
+  const seen = new Set(symbols.map((symbol) => `${symbol.name}\0${symbol.type}`));
+
+  for (const fileExport of file.exports) {
+    const key = `${fileExport.name}\0${fileExport.type}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    symbols.push({ ...fileExport, isExported: true });
+  }
+
+  return symbols;
 }
 
 function getModule(relativePath: string): string {

--- a/src/operations/formatters.ts
+++ b/src/operations/formatters.ts
@@ -24,6 +24,10 @@ function text(lines: readonly string[]): string {
   return lines.join("\n");
 }
 
+function signatureSuffix(signature: string | undefined): string {
+  return signature ? ` — ${signature}` : "";
+}
+
 /**
  * Format an overview operation result for human CLI output.
  */
@@ -84,7 +88,10 @@ export function formatFileContextText(result: FileContextResult | FileContextErr
   if (result.exports.length > 0) {
     lines.push(
       `Exports (${result.exports.length})`,
-      ...result.exports.map((fileExport) => `  ${fileExport.type.padEnd(12)} ${fileExport.name} (${fileExport.loc} LOC)`),
+      ...result.exports.map(
+        (fileExport) =>
+          `  ${fileExport.type.padEnd(12)} ${fileExport.name} (${fileExport.loc} LOC)${signatureSuffix(fileExport.typeFacts?.signature)}`,
+      ),
       "",
     );
   }
@@ -435,6 +442,11 @@ export function formatSymbolContextText(result: SymbolContextResult | SymbolCont
     `LOC:        ${result.loc}`,
     `Default:    ${result.isDefault ? "yes" : "no"}`,
     `Complexity: ${result.complexity}`,
+    ...(result.typeFacts ? [
+      `Signature:  ${result.typeFacts.signature}`,
+      `Consumes:   ${result.typeFacts.consumes.length > 0 ? result.typeFacts.consumes.join(", ") : "none"}`,
+      `Produces:   ${result.typeFacts.produces.length > 0 ? result.typeFacts.produces.join(", ") : "none"}`,
+    ] : []),
     `Fan-in:     ${result.fanIn}`,
     `Fan-out:    ${result.fanOut}`,
     `PageRank:   ${result.pageRank}`,

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2,7 +2,24 @@ import ts from "typescript";
 import path from "path";
 import fs from "fs";
 import { execFileSync } from "child_process";
-import type { ParsedFile, ParsedExport, ParsedImport, CallSite } from "../types/index.js";
+import type {
+  CallSite,
+  ParsedExport,
+  ParsedFile,
+  ParsedImport,
+} from "../types/index.js";
+import {
+  canHaveDeclarationTypeFacts,
+  declarationTypeFactsFromChecker,
+  declarationTypeFactsFromSyntax,
+  nodeLocation,
+} from "./type-facts.js";
+import {
+  computeComplexity,
+  extractSymbols,
+  extractSymbolsSyntax,
+  getExportType,
+} from "./symbols.js";
 
 interface PathAlias {
   pattern: string;
@@ -298,10 +315,11 @@ function parseFile(sourceFile: ts.SourceFile, checker: ts.TypeChecker | undefine
   const relativePath = path.relative(rootDir, filePath);
   const loc = sourceFile.getEnd() === 0 ? 0 : sourceFile.getLineAndCharacterOfPosition(sourceFile.getEnd() - 1).line + 1;
   const exports = checker ? extractExports(sourceFile, checker) : extractExportsSyntax(sourceFile);
+  const symbols = checker ? extractSymbols(sourceFile, checker) : extractSymbolsSyntax(sourceFile);
   const imports = extractImports(sourceFile, aliases);
   const callSites = checker ? extractCallSites(sourceFile, checker, rootDir) : [];
 
-  return { path: filePath, relativePath, loc, exports, imports, callSites, churn: 0, isTestFile: false };
+  return { path: filePath, relativePath, loc, exports, symbols, imports, callSites, churn: 0, isTestFile: false };
 }
 
 function extractExports(sourceFile: ts.SourceFile, checker: ts.TypeChecker): ParsedExport[] {
@@ -331,15 +349,15 @@ function extractExports(sourceFile: ts.SourceFile, checker: ts.TypeChecker): Par
     const isLocal = declSourceFile.fileName === sourceFile.fileName;
 
     const exportType = getExportType(decl);
-    const startLine = declSourceFile.getLineAndCharacterOfPosition(decl.getStart()).line;
-    const endLine = declSourceFile.getLineAndCharacterOfPosition(decl.getEnd()).line;
+    const { loc } = nodeLocation(declSourceFile, decl);
 
     exports.push({
       name: exportName,
       type: exportType,
-      loc: isLocal ? endLine - startLine + 1 : 1,
+      loc: isLocal ? loc : 1,
       isDefault: exportName === "default",
       complexity: isLocal ? computeComplexity(decl) : 0,
+      typeFacts: declarationTypeFactsFromChecker(exportName, decl, checker),
     });
   }
 
@@ -358,14 +376,14 @@ function extractExportsSyntax(sourceFile: ts.SourceFile): ParsedExport[] {
     if (seen.has(name)) return;
     seen.add(name);
 
-    const startLine = sourceFile.getLineAndCharacterOfPosition(node.getStart()).line;
-    const endLine = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line;
+    const { loc } = nodeLocation(sourceFile, node);
     exports.push({
       name,
       type,
-      loc: endLine - startLine + 1,
+      loc,
       isDefault,
       complexity: computeComplexity(node),
+      typeFacts: canHaveDeclarationTypeFacts(node) ? declarationTypeFactsFromSyntax(name, node) : undefined,
     });
   }
 
@@ -416,23 +434,6 @@ function extractExportsSyntax(sourceFile: ts.SourceFile): ParsedExport[] {
   });
 
   return exports;
-}
-
-function getExportType(node: ts.Declaration): ParsedExport["type"] {
-  if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isArrowFunction(node)) {
-    return "function";
-  }
-  if (ts.isClassDeclaration(node)) return "class";
-  if (ts.isInterfaceDeclaration(node)) return "interface";
-  if (ts.isTypeAliasDeclaration(node)) return "type";
-  if (ts.isEnumDeclaration(node)) return "enum";
-  if (ts.isVariableDeclaration(node)) {
-    const init = node.initializer;
-    if (init && (ts.isArrowFunction(init) || ts.isFunctionExpression(init))) {
-      return "function";
-    }
-  }
-  return "variable";
 }
 
 function extractImports(sourceFile: ts.SourceFile, aliases: PathAlias[]): ParsedImport[] {
@@ -635,35 +636,6 @@ function resolveExistingModulePath(basePath: string): string | null {
     if (fs.existsSync(candidate)) return candidate;
   }
   return null;
-}
-
-function computeComplexity(node: ts.Node): number {
-  let branches = 1;
-  function visit(n: ts.Node): void {
-    if (
-      ts.isIfStatement(n) ||
-      ts.isConditionalExpression(n) ||
-      ts.isCaseClause(n) ||
-      ts.isCatchClause(n) ||
-      ts.isForStatement(n) ||
-      ts.isForInStatement(n) ||
-      ts.isForOfStatement(n) ||
-      ts.isWhileStatement(n) ||
-      ts.isDoStatement(n)
-    ) {
-      branches++;
-    }
-    if (ts.isBinaryExpression(n)) {
-      if (n.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
-          n.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
-          n.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
-        branches++;
-      }
-    }
-    ts.forEachChild(n, visit);
-  }
-  ts.forEachChild(node, visit);
-  return branches;
 }
 
 function getGitChurn(rootDir: string): Map<string, number> {

--- a/src/parser/symbols.ts
+++ b/src/parser/symbols.ts
@@ -1,0 +1,138 @@
+import ts from "typescript";
+import type { ParsedExport, ParsedSymbol } from "../types/index.js";
+import {
+  declarationTypeFactsFromChecker,
+  declarationTypeFactsFromSyntax,
+  nodeLocation,
+} from "./type-facts.js";
+
+function parsedSymbol(
+  name: string,
+  type: ParsedExport["type"],
+  node: ts.Declaration,
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker | undefined,
+  isDefault: boolean,
+  isExported: boolean,
+): ParsedSymbol {
+  const { loc } = nodeLocation(sourceFile, node);
+  const typeFacts = checker
+    ? declarationTypeFactsFromChecker(name, node, checker)
+    : declarationTypeFactsFromSyntax(name, node);
+  return {
+    name,
+    type,
+    loc,
+    isDefault,
+    complexity: computeComplexity(node),
+    isExported,
+    typeFacts,
+  };
+}
+
+export function extractSymbols(sourceFile: ts.SourceFile, checker: ts.TypeChecker): ParsedSymbol[] {
+  return collectSymbols(sourceFile, checker);
+}
+
+export function extractSymbolsSyntax(sourceFile: ts.SourceFile): ParsedSymbol[] {
+  return collectSymbols(sourceFile, undefined);
+}
+
+function collectSymbols(sourceFile: ts.SourceFile, checker: ts.TypeChecker | undefined): ParsedSymbol[] {
+  const symbols: ParsedSymbol[] = [];
+  const seen = new Set<string>();
+
+  function addSymbol(name: string, type: ParsedExport["type"], node: ts.Declaration, isDefault = false, isExported = false): void {
+    const key = `${name}\0${type}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    symbols.push(parsedSymbol(name, type, node, sourceFile, checker, isDefault, isExported));
+  }
+
+  function visit(node: ts.Node): void {
+    const isExported = hasModifier(node, ts.SyntaxKind.ExportKeyword);
+    const isDefault = hasModifier(node, ts.SyntaxKind.DefaultKeyword);
+
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      addSymbol(isDefault ? "default" : node.name.text, "function", node, isDefault, isExported);
+    } else if (ts.isClassDeclaration(node) && node.name) {
+      addSymbol(isDefault ? "default" : node.name.text, "class", node, isDefault, isExported);
+      for (const member of node.members) {
+        if (ts.isMethodDeclaration(member) && ts.isIdentifier(member.name)) {
+          addSymbol(`${node.name.text}.${member.name.text}`, "function", member, false, false);
+        } else if (ts.isConstructorDeclaration(member)) {
+          addSymbol(`${node.name.text}.constructor`, "function", member, false, false);
+        }
+      }
+    } else if (ts.isInterfaceDeclaration(node)) {
+      addSymbol(node.name.text, "interface", node, false, isExported);
+    } else if (ts.isTypeAliasDeclaration(node)) {
+      addSymbol(node.name.text, "type", node, false, isExported);
+    } else if (ts.isEnumDeclaration(node)) {
+      addSymbol(node.name.text, "enum", node, false, isExported);
+    } else if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) continue;
+        const type = getExportType(declaration);
+        if (type === "function" || isExported) {
+          addSymbol(declaration.name.text, type, declaration, false, isExported);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return symbols;
+}
+
+export function getExportType(node: ts.Declaration): ParsedExport["type"] {
+  if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isArrowFunction(node)) {
+    return "function";
+  }
+  if (ts.isClassDeclaration(node)) return "class";
+  if (ts.isInterfaceDeclaration(node)) return "interface";
+  if (ts.isTypeAliasDeclaration(node)) return "type";
+  if (ts.isEnumDeclaration(node)) return "enum";
+  if (ts.isVariableDeclaration(node)) {
+    const init = node.initializer;
+    if (init && (ts.isArrowFunction(init) || ts.isFunctionExpression(init))) {
+      return "function";
+    }
+  }
+  return "variable";
+}
+
+export function computeComplexity(node: ts.Node): number {
+  let branches = 1;
+  function visit(n: ts.Node): void {
+    if (
+      ts.isIfStatement(n) ||
+      ts.isConditionalExpression(n) ||
+      ts.isCaseClause(n) ||
+      ts.isCatchClause(n) ||
+      ts.isForStatement(n) ||
+      ts.isForInStatement(n) ||
+      ts.isForOfStatement(n) ||
+      ts.isWhileStatement(n) ||
+      ts.isDoStatement(n)
+    ) {
+      branches++;
+    }
+    if (ts.isBinaryExpression(n)) {
+      if (n.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+          n.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
+          n.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
+        branches++;
+      }
+    }
+    ts.forEachChild(n, visit);
+  }
+  ts.forEachChild(node, visit);
+  return branches;
+}
+
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return ts.canHaveModifiers(node) && (ts.getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false);
+}

--- a/src/parser/type-facts.ts
+++ b/src/parser/type-facts.ts
@@ -1,0 +1,278 @@
+import ts from "typescript";
+import type {
+  ParameterTypeFact,
+  SymbolTypeFacts,
+  TypeParameterFact,
+} from "../types/index.js";
+
+type FunctionLikeWithBody =
+  | ts.FunctionDeclaration
+  | ts.MethodDeclaration
+  | ts.ConstructorDeclaration
+  | ts.ArrowFunction
+  | ts.FunctionExpression;
+
+const TYPE_REFERENCE_STOP_WORDS = new Set([
+  "Array",
+  "Date",
+  "Error",
+  "Map",
+  "Promise",
+  "Readonly",
+  "ReadonlyArray",
+  "Record",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+]);
+
+export function nodeLocation(sourceFile: ts.SourceFile, node: ts.Node): { loc: number; startLine: number; endLine: number } {
+  const startLine = sourceFile.getLineAndCharacterOfPosition(node.getStart()).line;
+  const endLine = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line;
+  return { loc: endLine - startLine + 1, startLine, endLine };
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function extractTypeReferences(typeText: string | undefined): string[] {
+  if (!typeText) return [];
+  const matches = typeText.match(/\b[A-Z][A-Za-z0-9_$]*\b/g) ?? [];
+  return uniqueSorted(matches.filter((name) => !TYPE_REFERENCE_STOP_WORDS.has(name)));
+}
+
+function parameterName(parameter: ts.ParameterDeclaration): string {
+  return ts.isIdentifier(parameter.name) ? parameter.name.text : parameter.name.getText();
+}
+
+function typeParameterFacts(typeParameters: ts.NodeArray<ts.TypeParameterDeclaration> | undefined): TypeParameterFact[] {
+  if (!typeParameters) return [];
+  return typeParameters.map((typeParameter) => ({
+    name: typeParameter.name.text,
+    constraint: typeParameter.constraint?.getText(),
+    default: typeParameter.default?.getText(),
+  }));
+}
+
+function typeParameterNames(typeParameters: ts.NodeArray<ts.TypeParameterDeclaration> | undefined): string[] {
+  if (!typeParameters) return [];
+  return typeParameters.map((typeParameter) => typeParameter.name.text);
+}
+
+function declarationTypeParameters(declaration: ts.Declaration): ts.NodeArray<ts.TypeParameterDeclaration> | undefined {
+  if (
+    ts.isClassDeclaration(declaration) ||
+    ts.isInterfaceDeclaration(declaration) ||
+    ts.isTypeAliasDeclaration(declaration) ||
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isArrowFunction(declaration) ||
+    ts.isFunctionExpression(declaration)
+  ) {
+    return declaration.typeParameters;
+  }
+  return undefined;
+}
+
+function declarationConsumes(name: string, declaration: ts.Declaration): string[] {
+  const excluded = new Set([name, ...typeParameterNames(declarationTypeParameters(declaration))]);
+  return extractTypeReferences(declaration.getText()).filter((typeName) => !excluded.has(typeName));
+}
+
+function parameterFactsFromSyntax(parameters: ts.NodeArray<ts.ParameterDeclaration>): ParameterTypeFact[] {
+  return parameters.map((parameter) => ({
+    name: parameterName(parameter),
+    type: parameter.type?.getText() ?? "unknown",
+    optional: parameter.questionToken !== undefined || parameter.initializer !== undefined,
+    rest: parameter.dotDotDotToken !== undefined,
+  }));
+}
+
+function parameterFactsFromChecker(
+  parameters: ts.NodeArray<ts.ParameterDeclaration>,
+  signature: ts.Signature,
+  checker: ts.TypeChecker,
+): ParameterTypeFact[] {
+  const signatureParameters = signature.getParameters();
+  return parameters.map((parameter, index) => {
+    const symbol = signatureParameters.at(index);
+    const type = symbol !== undefined
+      ? checker.getTypeOfSymbolAtLocation(symbol, parameter)
+      : checker.getTypeAtLocation(parameter);
+    const parameterType = checker.typeToString(type, parameter, ts.TypeFormatFlags.NoTruncation);
+    return {
+      name: parameterName(parameter),
+      type: parameterType,
+      optional: parameter.questionToken !== undefined || parameter.initializer !== undefined,
+      rest: parameter.dotDotDotToken !== undefined,
+    };
+  });
+}
+
+function functionSignatureText(
+  name: string,
+  parameters: readonly ParameterTypeFact[],
+  returnType: string | undefined,
+  typeParameters: readonly TypeParameterFact[],
+): string {
+  const typeParameterText = typeParameters.length > 0
+    ? `<${typeParameters.map((typeParameter) => {
+      const constraint = typeParameter.constraint ? ` extends ${typeParameter.constraint}` : "";
+      const defaultType = typeParameter.default ? ` = ${typeParameter.default}` : "";
+      return `${typeParameter.name}${constraint}${defaultType}`;
+    }).join(", ")}>`
+    : "";
+  const parameterText = parameters.map((parameter) => {
+    const rest = parameter.rest ? "..." : "";
+    const optional = parameter.optional && !parameter.rest ? "?" : "";
+    return `${rest}${parameter.name}${optional}: ${parameter.type}`;
+  }).join(", ");
+  return `${name}${typeParameterText}(${parameterText}): ${returnType ?? "unknown"}`;
+}
+
+function functionTypeFactsFromChecker(
+  name: string,
+  declaration: FunctionLikeWithBody,
+  checker: ts.TypeChecker,
+): SymbolTypeFacts | undefined {
+  const signature = checker.getSignatureFromDeclaration(declaration);
+  if (!signature) return undefined;
+  const parameters = parameterFactsFromChecker(declaration.parameters, signature, checker);
+  const returnType = checker.typeToString(checker.getReturnTypeOfSignature(signature), declaration, ts.TypeFormatFlags.NoTruncation);
+  const typeParameters = ts.isConstructorDeclaration(declaration)
+    ? []
+    : typeParameterFacts(declaration.typeParameters);
+  return {
+    signature: functionSignatureText(name, parameters, returnType, typeParameters),
+    parameters,
+    returnType,
+    typeParameters,
+    consumes: uniqueSorted(parameters.flatMap((parameter) => extractTypeReferences(parameter.type))),
+    produces: extractTypeReferences(returnType),
+    confidence: "resolved",
+  };
+}
+
+function functionTypeFactsFromSyntax(name: string, declaration: FunctionLikeWithBody): SymbolTypeFacts {
+  const parameters = parameterFactsFromSyntax(declaration.parameters);
+  const returnType = ts.isConstructorDeclaration(declaration) ? undefined : declaration.type?.getText();
+  const typeParameters = ts.isConstructorDeclaration(declaration)
+    ? []
+    : typeParameterFacts(declaration.typeParameters);
+  return {
+    signature: functionSignatureText(name, parameters, returnType, typeParameters),
+    parameters,
+    returnType,
+    typeParameters,
+    consumes: uniqueSorted(parameters.flatMap((parameter) => extractTypeReferences(parameter.type))),
+    produces: extractTypeReferences(returnType),
+    confidence: "syntax",
+  };
+}
+
+export function declarationTypeFactsFromChecker(
+  name: string,
+  declaration: ts.Declaration,
+  checker: ts.TypeChecker,
+): SymbolTypeFacts | undefined {
+  if (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isConstructorDeclaration(declaration) ||
+    ts.isArrowFunction(declaration) ||
+    ts.isFunctionExpression(declaration)
+  ) {
+    return functionTypeFactsFromChecker(name, declaration, checker);
+  }
+
+  if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+    if (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer)) {
+      return functionTypeFactsFromChecker(name, declaration.initializer, checker);
+    }
+  }
+
+  const typeText = checker.typeToString(checker.getTypeAtLocation(declaration), declaration, ts.TypeFormatFlags.NoTruncation);
+  const shapeDeclaration = ts.isInterfaceDeclaration(declaration)
+    || ts.isTypeAliasDeclaration(declaration)
+    || ts.isClassDeclaration(declaration)
+    || ts.isEnumDeclaration(declaration);
+  return {
+    signature: `${name}: ${typeText}`,
+    parameters: [],
+    returnType: typeText,
+    typeParameters: ts.isInterfaceDeclaration(declaration) || ts.isTypeAliasDeclaration(declaration)
+      ? typeParameterFacts(declaration.typeParameters)
+      : [],
+    consumes: declarationConsumes(name, declaration),
+    produces: shapeDeclaration ? [name] : extractTypeReferences(typeText),
+    confidence: "resolved",
+  };
+}
+
+export function declarationTypeFactsFromSyntax(name: string, declaration: ts.Declaration): SymbolTypeFacts | undefined {
+  if (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isConstructorDeclaration(declaration) ||
+    ts.isArrowFunction(declaration) ||
+    ts.isFunctionExpression(declaration)
+  ) {
+    return functionTypeFactsFromSyntax(name, declaration);
+  }
+
+  if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+    if (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer)) {
+      return functionTypeFactsFromSyntax(name, declaration.initializer);
+    }
+  }
+
+  if (ts.isTypeAliasDeclaration(declaration)) {
+    const typeText = declaration.type.getText();
+    return {
+      signature: `type ${name} = ${typeText}`,
+      parameters: [],
+      returnType: typeText,
+      typeParameters: typeParameterFacts(declaration.typeParameters),
+      consumes: declarationConsumes(name, declaration),
+      produces: [name],
+      confidence: "syntax",
+    };
+  }
+
+  if (ts.isInterfaceDeclaration(declaration)) {
+    return {
+      signature: `interface ${name}`,
+      parameters: [],
+      typeParameters: typeParameterFacts(declaration.typeParameters),
+      consumes: declarationConsumes(name, declaration),
+      produces: [name],
+      confidence: "syntax",
+    };
+  }
+
+  if (ts.isClassDeclaration(declaration) || ts.isEnumDeclaration(declaration)) {
+    const kind = ts.isClassDeclaration(declaration) ? "class" : "enum";
+    return {
+      signature: `${kind} ${name}`,
+      parameters: [],
+      typeParameters: ts.isClassDeclaration(declaration) ? typeParameterFacts(declaration.typeParameters) : [],
+      consumes: declarationConsumes(name, declaration),
+      produces: [name],
+      confidence: "syntax",
+    };
+  }
+
+  return undefined;
+}
+
+export function canHaveDeclarationTypeFacts(node: ts.Node): node is ts.Declaration {
+  return ts.isFunctionDeclaration(node)
+    || ts.isClassDeclaration(node)
+    || ts.isInterfaceDeclaration(node)
+    || ts.isTypeAliasDeclaration(node)
+    || ts.isEnumDeclaration(node)
+    || ts.isVariableDeclaration(node)
+    || ts.isMethodDeclaration(node)
+    || ts.isConstructorDeclaration(node);
+}

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,15 +1,15 @@
-import type { CodebaseGraph } from "../types/index.js";
+import type { CodebaseGraph, SymbolTypeFacts } from "../types/index.js";
 
 interface SearchDocument {
   file: string;
-  symbols: Array<{ name: string; type: string; loc: number }>;
+  symbols: Array<{ name: string; type: string; loc: number; typeFacts?: SymbolTypeFacts }>;
   terms: string[];
 }
 
 interface SearchResult {
   file: string;
   score: number;
-  symbols: Array<{ name: string; type: string; loc: number; score: number }>;
+  symbols: Array<{ name: string; type: string; loc: number; score: number; typeFacts?: SymbolTypeFacts }>;
 }
 
 export interface SearchIndex {
@@ -31,12 +31,23 @@ export function tokenize(text: string): string[] {
   return parts;
 }
 
+function typeFactTerms(typeFacts: SymbolTypeFacts | undefined): string[] {
+  if (!typeFacts) return [];
+  return [
+    ...tokenize(typeFacts.signature),
+    ...typeFacts.parameters.flatMap((parameter) => tokenize(parameter.type)),
+    ...typeFacts.consumes.flatMap((shape) => tokenize(shape)),
+    ...typeFacts.produces.flatMap((shape) => tokenize(shape)),
+    ...(typeFacts.returnType ? tokenize(typeFacts.returnType) : []),
+  ];
+}
+
 /** Build BM25 search index from a CodebaseGraph */
 export function createSearchIndex(graph: CodebaseGraph): SearchIndex {
   const documents: SearchDocument[] = [];
 
   // Group symbols by file
-  const fileSymbols = new Map<string, Array<{ name: string; type: string; loc: number }>>();
+  const fileSymbols = new Map<string, Array<{ name: string; type: string; loc: number; typeFacts?: SymbolTypeFacts }>>();
   for (const node of graph.nodes) {
     if (node.type === "file") continue;
     const file = node.parentFile ?? node.path;
@@ -48,8 +59,11 @@ export function createSearchIndex(graph: CodebaseGraph): SearchIndex {
   // Also add from symbolNodes (call graph symbols)
   for (const sym of graph.symbolNodes) {
     const existing = fileSymbols.get(sym.file) ?? [];
-    if (!existing.some((s) => s.name === sym.name)) {
-      existing.push({ name: sym.name, type: sym.type, loc: sym.loc });
+    const existingSymbol = existing.find((s) => s.name === sym.name);
+    if (existingSymbol) {
+      existingSymbol.typeFacts = existingSymbol.typeFacts ?? sym.typeFacts;
+    } else {
+      existing.push({ name: sym.name, type: sym.type, loc: sym.loc, typeFacts: sym.typeFacts });
       fileSymbols.set(sym.file, existing);
     }
   }
@@ -62,6 +76,7 @@ export function createSearchIndex(graph: CodebaseGraph): SearchIndex {
       ...tokenize(node.id),
       ...tokenize(node.label),
       ...symbols.flatMap((s) => tokenize(s.name)),
+      ...symbols.flatMap((s) => typeFactTerms(s.typeFacts)),
     ];
     documents.push({ file: node.id, symbols, terms });
   }
@@ -121,7 +136,7 @@ export function search(index: SearchIndex, query: string, limit = 20): SearchRes
     if (docScore > 0) {
       // Score individual symbols too
       const symbolScores = doc.symbols.map((sym) => {
-        const symTerms = tokenize(sym.name);
+        const symTerms = [...tokenize(sym.name), ...typeFactTerms(sym.typeFacts)];
         let symScore = 0;
         for (const qt of queryTerms) {
           if (symTerms.includes(qt)) symScore += 1;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface ParsedFile {
   relativePath: string;
   loc: number;
   exports: ParsedExport[];
+  symbols?: ParsedSymbol[];
   imports: ParsedImport[];
   callSites: CallSite[];
   churn: number;
@@ -14,12 +15,40 @@ export interface ParsedFile {
   testFile?: string;
 }
 
+export interface TypeParameterFact {
+  name: string;
+  constraint?: string;
+  default?: string;
+}
+
+export interface ParameterTypeFact {
+  name: string;
+  type: string;
+  optional: boolean;
+  rest: boolean;
+}
+
+export interface SymbolTypeFacts {
+  signature: string;
+  parameters: ParameterTypeFact[];
+  returnType?: string;
+  typeParameters: TypeParameterFact[];
+  consumes: string[];
+  produces: string[];
+  confidence: "resolved" | "syntax";
+}
+
 export interface ParsedExport {
   name: string;
   type: "function" | "class" | "variable" | "type" | "interface" | "enum";
   loc: number;
   isDefault: boolean;
   complexity: number;
+  typeFacts?: SymbolTypeFacts;
+}
+
+export interface ParsedSymbol extends ParsedExport {
+  isExported: boolean;
 }
 
 export interface ParsedImport {
@@ -73,6 +102,8 @@ export interface SymbolNode {
   loc: number;
   isDefault: boolean;
   complexity: number;
+  isExported?: boolean;
+  typeFacts?: SymbolTypeFacts;
 }
 
 export interface SymbolMetrics {

--- a/tests/operation-registry.e2e.test.ts
+++ b/tests/operation-registry.e2e.test.ts
@@ -449,6 +449,60 @@ describe("operation registry chained parity", () => {
     expect(withoutCache(parseJsonObject(second.stdout))).toEqual(withoutCache(parseJsonObject(first.stdout)));
   });
 
+  it("CH-P1-03: type/shape facts flow through real CLI and MCP surfaces", async () => {
+    runCliJson(["overview", getFixtureSrcPath()]);
+    const cachedRun = { force: false };
+
+    const cliFile = runCliJson(["file", getFixtureSrcPath(), "users/user-service.ts"], cachedRun);
+    const fileExports = cliFile.exports;
+    expect(Array.isArray(fileExports)).toBe(true);
+    if (!Array.isArray(fileExports)) throw new Error("Expected file exports array");
+    const userServiceExport = fileExports.find((fileExport) =>
+      isRecord(fileExport) && fileExport.name === "UserService"
+    );
+    expect(userServiceExport).toMatchObject({
+      name: "UserService",
+      typeFacts: {
+        produces: ["UserService"],
+        confidence: "resolved",
+      },
+    });
+
+    const cliSymbol = runCliJson(["symbol", getFixtureSrcPath(), "UserService.createUser"], cachedRun);
+    expect(cliSymbol).toMatchObject({
+      name: "UserService.createUser",
+      typeFacts: {
+        returnType: "User",
+        consumes: ["CreateUserInput"],
+        produces: ["User"],
+        confidence: "resolved",
+      },
+    });
+
+    const cliSearch = runCliJson(["search", getFixtureSrcPath(), "CreateUserInput", "--limit", "5"], cachedRun);
+    const searchResults = cliSearch.results;
+    expect(Array.isArray(searchResults)).toBe(true);
+    if (!Array.isArray(searchResults)) throw new Error("Expected search results array");
+    const searchSymbols: unknown[] = [];
+    for (const result of searchResults) {
+      if (!isRecord(result) || !Array.isArray(result.symbols)) continue;
+      for (const symbol of result.symbols) {
+        searchSymbols.push(symbol);
+      }
+    }
+    expect(searchSymbols.some((symbol) =>
+      isRecord(symbol)
+      && symbol.name === "UserService.createUser"
+      && isRecord(symbol.typeFacts)
+      && Array.isArray(symbol.typeFacts.consumes)
+      && symbol.typeFacts.consumes.includes("CreateUserInput")
+    )).toBe(true);
+
+    const mcp = await createFixtureMcp();
+    const mcpSymbol = await mcp.callTool("symbol_context", { name: "UserService.createUser" });
+    expect(withoutNextSteps(mcpSymbol)).toEqual(withoutCache(cliSymbol));
+  });
+
   it("CH-P1-01: registry-adapted MCP tools match descriptor runs for every operation", async () => {
     const { codebaseGraph } = getFixturePipeline();
     const mcp = await createFixtureMcp();

--- a/tests/phase1-red.test.ts
+++ b/tests/phase1-red.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getFixturePipeline } from "./helpers/pipeline.js";
+import { computeFileContext } from "../src/core/index.js";
 import path from "path";
 import fs from "fs";
 
@@ -63,6 +64,18 @@ describe("1.1 — parser re-export resolution", () => {
     expect(toAuthService).toBeDefined();
     if (!toAuthService) return;
     expect(toAuthService.symbols).toContain("AuthService");
+  });
+
+  it("file context keeps barrel re-export symbols", () => {
+    const { codebaseGraph } = getFixturePipeline();
+    const context = computeFileContext(codebaseGraph, "auth/index.ts");
+    expect(context).not.toHaveProperty("error");
+    if ("error" in context) throw new Error(context.error);
+
+    const exportNames = context.exports.map((fileExport) => fileExport.name);
+    expect(exportNames).toContain("AuthService");
+    expect(exportNames).toContain("authenticate");
+    expect(exportNames).toContain("requireAuth");
   });
 });
 

--- a/tests/type-shape.test.ts
+++ b/tests/type-shape.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { analyzeGraph } from "../src/analyzer/index.js";
+import { computeFileContext, computeSearch, computeSymbolContext } from "../src/core/index.js";
+import { buildGraph } from "../src/graph/index.js";
+import { parseCodebase } from "../src/parser/index.js";
+import type { CodebaseGraph } from "../src/types/index.js";
+
+let projectDir: string;
+let graph: CodebaseGraph;
+
+function writeProjectFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(path.join(projectDir, filePath)), { recursive: true });
+  fs.writeFileSync(path.join(projectDir, filePath), content);
+}
+
+describe("type/shape facts", () => {
+  beforeAll(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "cbi-type-shape-"));
+    writeProjectFile(
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "Node16",
+          moduleResolution: "Node16",
+          baseUrl: ".",
+          paths: {
+            "@models": ["models.ts"],
+          },
+        },
+      }),
+    );
+    writeProjectFile(
+      "models.ts",
+      `export type UserRole = "admin" | "member";
+
+export interface User {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface CreateUserInput {
+  email: string;
+  role: UserRole;
+}
+
+export type Result<T> = {
+  value: T;
+  error?: string;
+};
+`,
+    );
+    writeProjectFile(
+      "index.ts",
+      `import type { CreateUserInput, Result, User } from "@models";
+
+export function createUser(input: CreateUserInput): User {
+  return { id: "1", email: input.email, role: input.role };
+}
+
+export const wrapUser = <T extends User>(value: T): Result<T> => ({ value });
+
+export default function unwrap(result: Result<User>): User {
+  return result.value;
+}
+
+export class UserController {
+  save(input: CreateUserInput): Result<User> {
+    return wrapUser(createUser(input));
+  }
+}
+
+export function unresolved(input: MissingShape): MissingShape {
+  return input;
+}
+`,
+    );
+
+    const parsedFiles = parseCodebase(projectDir);
+    graph = analyzeGraph(buildGraph(parsedFiles), parsedFiles);
+  });
+
+  afterAll(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("CH-P1-03: parses resolved, generic, default, and unresolved type facts", () => {
+    const parsed = parseCodebase(projectDir);
+    const index = parsed.find((file) => file.relativePath === "index.ts");
+    const createUser = index?.exports.find((fileExport) => fileExport.name === "createUser");
+    const wrapUser = index?.exports.find((fileExport) => fileExport.name === "wrapUser");
+    const defaultExport = index?.exports.find((fileExport) => fileExport.name === "default");
+    const unresolved = index?.exports.find((fileExport) => fileExport.name === "unresolved");
+    const models = parsed.find((file) => file.relativePath === "models.ts");
+    const user = models?.exports.find((fileExport) => fileExport.name === "User");
+    const createUserInput = models?.exports.find((fileExport) => fileExport.name === "CreateUserInput");
+
+    expect(createUser?.typeFacts).toMatchObject({
+      parameters: [{ name: "input", type: "CreateUserInput", optional: false, rest: false }],
+      returnType: "User",
+      consumes: ["CreateUserInput"],
+      produces: ["User"],
+      confidence: "resolved",
+    });
+    expect(wrapUser?.typeFacts?.typeParameters).toEqual([{ name: "T", constraint: "User", default: undefined }]);
+    expect(wrapUser?.typeFacts?.returnType).toContain("Result");
+    expect(defaultExport?.typeFacts?.signature).toContain("default(result: Result<User>): User");
+    expect(unresolved?.typeFacts?.consumes).toContain("MissingShape");
+    expect(unresolved?.typeFacts?.produces).toContain("MissingShape");
+    expect(user?.typeFacts).toMatchObject({ consumes: ["UserRole"], produces: ["User"] });
+    expect(createUserInput?.typeFacts).toMatchObject({ consumes: ["UserRole"], produces: ["CreateUserInput"] });
+  });
+
+  it("CH-P1-03: exposes type facts through file, symbol, and search result objects", () => {
+    const fileContext = computeFileContext(graph, "index.ts");
+    expect(fileContext).not.toHaveProperty("error");
+    if ("error" in fileContext) throw new Error(fileContext.error);
+
+    const exportedFunction = fileContext.exports.find((fileExport) => fileExport.name === "createUser");
+    expect(exportedFunction?.typeFacts?.signature).toContain("createUser(input: CreateUserInput): User");
+
+    const symbolContext = computeSymbolContext(graph, "UserController.save");
+    expect(symbolContext).not.toHaveProperty("error");
+    if ("error" in symbolContext) throw new Error(symbolContext.error);
+    expect(symbolContext.typeFacts).toMatchObject({
+      returnType: "Result<User>",
+      consumes: ["CreateUserInput"],
+      produces: ["Result", "User"],
+    });
+
+    const search = computeSearch(graph, "CreateUserInput", 5);
+    const matchedSymbols = search.results.flatMap((result) => result.symbols);
+    expect(matchedSymbols.some((symbol) => symbol.name === "createUser" && symbol.typeFacts?.consumes.includes("CreateUserInput"))).toBe(true);
+    expect(matchedSymbols.some((symbol) => symbol.name === "UserController.save" && symbol.typeFacts?.consumes.includes("CreateUserInput"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add parser type/shape facts for exported/local symbols: signatures, parameters, return types, consumed/produced shapes, confidence
- propagate type facts through graph symbol nodes, file context, symbol context, search, CLI text formatters, and MCP/CLI JSON surfaces
- keep parser organization explicit with `parser/type-facts.ts` and `parser/symbols.ts`; preserve barrel re-export symbols in file context
- sync docs/llms/roadmap for the 2.5.0 Type/Shape foundation slice

## Roadmap
- 2.5.0 / P1 Type/Shape Layer foundation slice
- CH-P1-03: parser -> graph -> core -> search -> CLI/MCP type/shape facts

## Tests / Gates
- `pnpm exec eslint src/types/index.ts src/parser/index.ts src/parser/type-facts.ts src/parser/symbols.ts src/graph/index.ts src/core/index.ts src/search/index.ts src/operations/formatters.ts tests/type-shape.test.ts tests/operation-registry.e2e.test.ts tests/phase1-red.test.ts`
- `pnpm typecheck`
- `pnpm build`
- focused regression chain: 85 tests passed
- `pnpm test`: 32 files, 455 tests passed
- `pnpm verify:cli-real`: pass=56 fail=0
- `git diff --check`
- hygiene scan: no added `any`, `as` assertion, TS ignore, TS expect-error, or eslint-disable

## Dogfood
- `node dist/cli.js file tests/fixture-codebase/src auth/index.ts --json --force` preserves barrel exports: `AuthService`, `authenticate`, `requireAuth`, etc.
- `node dist/cli.js search tests/fixture-codebase/src CreateUserInput --limit 3 --json --force` returns `UserService.createUser` with `consumes: [CreateUserInput]`, `produces: [User]`
- `codebase-intelligence changes . --json --force`: 19 changed files, 37 affected files, 11 changed symbols

## Code Review
- artifact: `/tmp/code-review-type-shape-facts.json`
- mode: Deep
- coverage: 75/75 hunks, 18/18 rules
- verdict: CLEAN
