### PR TITLE
feat: add duplicate family detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Common workflows:
 ```bash
 npx codebase-intelligence hotspots ./src --metric complexity --limit 10
 npx codebase-intelligence opportunities ./src --limit 10
+npx codebase-intelligence duplicates ./src --mode mild --min-tokens 30
 npx codebase-intelligence impact ./src parseCodebase
 npx codebase-intelligence dead-exports ./src --limit 20
 npx codebase-intelligence changes ./src --json
@@ -56,7 +57,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 
 ## Features
 
-- **18 CLI commands** for architecture analysis, dependency impact, improvement opportunities, dead code detection, search, CI rules, and agent setup
+- **19 CLI commands** for architecture analysis, dependency impact, duplicate families, improvement opportunities, dead code detection, search, CI rules, and agent setup
 - **Machine-readable JSON output** (`--json`) for automation and CI pipelines
 - **Auto-cached index** in `.codebase-intelligence/` for fast repeat queries
 - **Cache migration facts** in JSON (`cacheDir`, `legacyCacheDir`, `migrated`, `gitignoreUpdated`, `warnings[]`)
@@ -66,7 +67,7 @@ claude mcp add -s user -t stdio codebase-intelligence -- npx -y codebase-intelli
 - **Process tracing** — detect entry points and execution flows through the call graph
 - **Community detection** — Louvain clustering for natural file groupings
 - **Agent adoption** — `init` writes per-agent instruction files + installs a skill so AI agents query CI before grep/read
-- **MCP parity (secondary)** — same analysis and rules gate available as 17 MCP tools, 2 prompts, and 3 resources
+- **MCP parity (secondary)** — same analysis and rules gate available as 18 MCP tools, 2 prompts, and 3 resources
 
 ## Installation
 
@@ -103,6 +104,7 @@ codebase-intelligence <command> <path> [options]
 | `forces` | Cohesion/tension/escape-velocity analysis |
 | `dead-exports` | Unused export detection |
 | `opportunities` | Ranked code-quality and refactoring opportunities |
+| `duplicates` | Duplicate function families (`strict`, `mild`, `weak`) |
 | `groups` | Top-level directory groups + aggregate metrics |
 | `symbol` | Callers/callees and symbol metrics |
 | `impact` | Symbol-level blast radius |
@@ -121,6 +123,10 @@ codebase-intelligence <command> <path> [options]
 | `--limit <n>` | Limit results on supported commands |
 | `--metric <m>` | Select ranking metric for `hotspots` |
 | `--scope <s>` | Select git diff scope for `changes`: `staged`, `unstaged`, `all` |
+| `--mode <m>` | Select clone mode for `duplicates`: `strict`, `mild`, `weak` |
+| `--min-tokens <n>` | Minimum duplicate token size for `duplicates` |
+| `--skip-local` | Ignore duplicate families confined to one file |
+| `--trace <id>` | Return token evidence for one duplicate family |
 
 The scanner always excludes common generated and agent-workspace directories such as `.codebase-intelligence/`, legacy `.code-visualizer/`, `.next/`, `dist/`, `coverage/`, `.worktrees/`, and `.claude/worktrees/`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ CLI (commander)
   |
   v
 Parser (TS Compiler API)
-  | extracts: files, exports, symbols, type facts, imports, LOC, complexity, churn, test mapping
+  | extracts: files, exports, symbols, type facts, duplicate tokens, imports, LOC, complexity, churn, test mapping
   v
 Graph Builder (graphology)
   | creates: nodes (file + function), edges (imports with symbols/weights)
@@ -25,7 +25,7 @@ Core (shared computation)
   |     typed descriptors, input schemas, CLI/MCP adapters, result wrappers, text formatters
   v
 MCP (stdio)                    CLI (terminal/CI)
-  | 17 tools, 2 prompts,        | 18 commands with text + JSON
+  | 18 tools, 2 prompts,        | 19 commands with text + JSON
   | 3 resources for LLMs        | output for humans and CI
 ```
 
@@ -36,6 +36,7 @@ src/
   types/index.ts       <- ALL interfaces (single source of truth)
   parser/index.ts      <- Parse orchestration + imports/exports/call sites + git churn/test detection
   parser/type-facts.ts <- Type signatures, parameters, consumed/produced shape facts
+  parser/duplication.ts <- Function-body clone token extraction
   parser/symbols.ts    <- Symbol inventory + symbol complexity
   graph/index.ts       <- graphology graph + symbol/type graph + circular dep detection
   analyzer/index.ts    <- All metric computation
@@ -43,9 +44,10 @@ src/
   core/index.ts        <- Shared result computation (MCP + CLI)
   operations/index.ts  <- Analysis operation descriptors + typed input schemas
   operations/formatters.ts <- Result-object text formatters for CLI commands
+  duplication/index.ts <- Duplicate family detection + trace evidence
   config/index.ts      <- Config discovery + zod validation
   rules/index.ts       <- Rules engine + registry (check command + MCP check tool)
-  mcp/index.ts         <- 17 MCP tools for LLM integration
+  mcp/index.ts         <- 18 MCP tools for LLM integration
   mcp/hints.ts         <- Operation-keyed next-step hints for MCP tool responses
   impact/index.ts      <- Symbol-level impact analysis + rename planning
   search/index.ts      <- BM25 search engine
@@ -67,7 +69,7 @@ loadCodebaseGraph(rootDir)
   -> otherwise emits progress events through parse/build/analyze/cache
 
 parseCodebase(rootDir)
-  -> ParsedFile[] (with churn, complexity, test mapping, symbol type facts)
+  -> ParsedFile[] (with churn, complexity, test mapping, symbol type facts, duplicate token facts)
 
 buildGraph(parsedFiles)
   -> BuiltGraph { graph: Graph, nodes: GraphNode[], edges: GraphEdge[] }
@@ -80,7 +82,7 @@ analyzeGraph(builtGraph, parsedFiles)
      }
 
 startMcpServer(codebaseGraph)
-  -> stdio MCP server with 17 tools, 2 prompts, 3 resources
+  -> stdio MCP server with 18 tools, 2 prompts, 3 resources
 
 runOperation(operation, codebaseGraph, input, context)
   -> { ok: true, data } | { ok: false, error, data? }
@@ -91,6 +93,7 @@ runOperation(operation, codebaseGraph, input, context)
 - **Dual interface**: MCP stdio for LLM agents, CLI subcommands for humans/CI. Both consume `src/core/`.
 - **Operation registry foundation**: Analysis operations now have typed descriptors in `src/operations/` with operation names, CLI command names, MCP tool names, input schemas, discriminated run results, and result-object text formatters. MCP tool registration and CLI command execution consume those descriptors; CLI JSON remains raw result data plus cache facts.
 - **Type/Shape facts**: Full-program parsing stores compact parameter/return/type-parameter facts on parsed symbols. `file`, `symbol`, and `search` JSON expose those facts additively; search indexes consumed/produced shape tokens so agents can ask which symbols touch a shape without a new command.
+- **Duplication families**: Parser stores deterministic function-body token streams on symbols. `duplicates` / `find_duplicates` groups symbols into strict, renamed, and near-miss clone families, with optional trace evidence for AI agents before refactors.
 - **Shared graph-load pipeline**: CLI commands and MCP stdio startup both use `src/graph-loader/` for path checks, legacy cache migration, cache reuse, parse/build/analyze, optional persistence, and stderr progress events.
 - **graphology**: In-memory graph with O(1) neighbor lookup. PageRank and betweenness computed via graphology-metrics.
 - **Batch git churn**: Single `git log --all --name-only` call, parsed for all files. Avoids O(n) subprocess spawning.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-18 commands for terminal and CI use. The 16 analysis commands have full parity with MCP tools and auto-cache the index to `.codebase-intelligence/`; `check` runs the rules gate; `init` sets up agent adoption.
+19 commands for terminal and CI use. The 17 analysis commands have full parity with MCP tools and auto-cache the index to `.codebase-intelligence/`; `check` runs the rules gate; `init` sets up agent adoption.
 
 ## Commands
 
@@ -106,6 +106,18 @@ codebase-intelligence opportunities <path> [--limit <n>] [--json] [--force]
 
 **Output:** ranked opportunities with kind, priority, confidence, score, target, evidence, and suggested follow-up commands.
 
+### duplicates
+
+Detect duplicate function families.
+
+```bash
+codebase-intelligence duplicates <path> [--mode <mode>] [--min-tokens <n>] [--skip-local] [--trace <id>] [--json] [--force]
+```
+
+**Modes:** `strict` preserves identifiers/literals, `mild` normalizes identifiers/literals for renamed clones, `weak` uses deterministic sequence similarity for near-miss clones.
+
+**Output:** duplicate family IDs, member symbols, token counts, similarity threshold/score, and optional trace evidence for one family.
+
 ### groups
 
 Top-level directory groups with aggregate metrics.
@@ -209,6 +221,10 @@ codebase-intelligence init [path] [--agents <list>] [--all] [--skill] [--gitigno
 | `--force` | All commands | Re-parse even if cached index matches HEAD |
 | `--metric <m>` | hotspots | Metric to rank by (default: coupling) |
 | `--limit <n>` | hotspots, search, dead-exports, opportunities, processes | Max results |
+| `--mode <m>` | duplicates | Clone mode: strict, mild, weak |
+| `--min-tokens <n>` | duplicates | Minimum function body token count (default: 30) |
+| `--skip-local` | duplicates | Ignore families confined to one file |
+| `--trace <id>` | duplicates | Return token evidence for one family id |
 | `--scope <s>` | changes | Git diff scope: staged, unstaged, all |
 | `--depth <n>` | dependents | Max traversal depth (default: 2) |
 | `--cohesion <n>` | forces | Min cohesion threshold (default: 0.6) |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,6 +24,7 @@ ParsedExport {
   isDefault: boolean
   complexity: number      // Cyclomatic complexity (branch count, min 1)
   typeFacts?: SymbolTypeFacts
+  duplication?: SymbolDuplicationFacts
 }
 
 ParsedSymbol extends ParsedExport {
@@ -38,6 +39,12 @@ SymbolTypeFacts {
   consumes: string[]      // Shape/type names read by parameters
   produces: string[]      // Shape/type names returned or declared
   confidence: "resolved" | "syntax"
+}
+
+SymbolDuplicationFacts {
+  tokenCount: number
+  tokens: Record<"strict" | "mild" | "weak", string[]> // Function-body token streams
+  hashes: Record<"strict" | "mild" | "weak", string>  // Deterministic family grouping keys
 }
 
 ParsedImport {
@@ -79,6 +86,7 @@ SymbolNode {
   complexity: number
   isExported?: boolean
   typeFacts?: SymbolTypeFacts
+  duplication?: SymbolDuplicationFacts
 }
 ```
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-17 tools available via MCP stdio.
+18 tools available via MCP stdio.
 
 Operation tools return JSON text payloads. Invalid operation inputs return `isError: true` with `{ "error": "..." }` using the same descriptor validation messages as CLI bad-argument exits.
 
@@ -89,7 +89,17 @@ Rank code quality and refactoring opportunities for AI agents.
 **Use when:** "What should I improve?" "Find refactoring opportunities." "Which files need tests?"
 **Not for:** Raw metric lists only (use find_hotspots or analyze_forces).
 
-## 9. get_groups
+## 9. find_duplicates
+
+Detect duplicate function families.
+
+**Input:** `{ mode?: "strict" | "mild" | "weak", minTokens?: number, skipLocal?: boolean, trace?: string }`
+**Returns:** mode, minTokens, threshold, totalCandidates, totalFamilies, families[] (id, members[], tokenCount, similarity), optional trace token evidence
+
+**Use when:** Finding copy-paste logic, renamed clones, near-miss drift, or refactor candidates.
+**Not for:** Unused code (use find_dead_exports) or module-level cohesion (use analyze_forces).
+
+## 10. get_groups
 
 Top-level directory groups with aggregate metrics.
 
@@ -99,7 +109,7 @@ Top-level directory groups with aggregate metrics.
 **Use when:** "What are the main areas of this codebase?" High-level grouping overview.
 **Not for:** Detailed module metrics (use get_module_structure).
 
-## 10. symbol_context
+## 11. symbol_context
 
 Callers, callees, and importance metrics for a function, class, or method.
 
@@ -109,7 +119,7 @@ Callers, callees, and importance metrics for a function, class, or method.
 **Use when:** "Who calls X?" "Trace this function." "What depends on this symbol?"
 **Not for:** Text search (use search) or file-level dependencies (use get_dependents).
 
-## 11. search
+## 12. search
 
 Search files and symbols by keyword.
 
@@ -119,7 +129,7 @@ Search files and symbols by keyword.
 **Use when:** "Find files related to auth." "Where is getUserById defined?"
 **Not for:** Structured call graph queries (use symbol_context).
 
-## 12. detect_changes
+## 13. detect_changes
 
 Detect changed files from git diff with risk metrics.
 
@@ -129,7 +139,7 @@ Detect changed files from git diff with risk metrics.
 **Use when:** Starting a review, triaging changes, "what changed?"
 **Not for:** Symbol-level impact (use impact_analysis).
 
-## 13. impact_analysis
+## 14. impact_analysis
 
 Symbol-level blast radius with depth-grouped risk labels.
 
@@ -139,7 +149,7 @@ Symbol-level blast radius with depth-grouped risk labels.
 **Use when:** "What breaks if I change getUserById?" Symbol-level impact assessment.
 **Not for:** File-level dependencies (use get_dependents).
 
-## 14. rename_symbol
+## 15. rename_symbol
 
 Read-only reference finder for rename planning.
 
@@ -149,7 +159,7 @@ Read-only reference finder for rename planning.
 **Use when:** Planning a rename, finding all usages of a symbol.
 **Not for:** Call graph analysis (use symbol_context).
 
-## 15. get_processes
+## 16. get_processes
 
 Trace execution flows from entry points through the call graph.
 
@@ -159,7 +169,7 @@ Trace execution flows from entry points through the call graph.
 **Use when:** "How does this app start?" "Trace request flow." "What are the entry points?"
 **Not for:** Static file dependencies (use get_dependents).
 
-## 16. get_clusters
+## 17. get_clusters
 
 Community-detected clusters of related files.
 
@@ -169,7 +179,7 @@ Community-detected clusters of related files.
 **Use when:** "What files are related?" "Find natural groupings." Discovering emergent groupings that differ from directory structure.
 **Not for:** Directory-based modules (use get_module_structure).
 
-## 17. check
+## 18. check
 
 Run the configurable rules engine and gate on findings.
 
@@ -208,6 +218,7 @@ Rules: `no-comments` (off by default), `no-circular-deps` (error), `no-dead-expo
 | "Which files need tests?" | `find_hotspots` (coverage) |
 | "What should I improve first?" | `find_opportunities` |
 | "Find refactoring opportunities." | `find_opportunities` |
+| "Where is logic duplicated?" | `find_duplicates` |
 | "What can I safely delete?" | `find_dead_exports` |
 | "How are modules organized?" | `get_module_structure` |
 | "What's architecturally wrong?" | `analyze_forces` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -31,8 +31,8 @@ Core (shared computation)
   |     typed descriptors, input schemas, CLI/MCP adapters, result wrappers, text formatters
   v
 MCP (stdio) + CLI
-  | MCP: 17 tools, 2 prompts, 3 resources for LLM agents
-  | CLI: 18 commands with formatted + JSON output for humans/CI
+  | MCP: 18 tools, 2 prompts, 3 resources for LLM agents
+  | CLI: 19 commands with formatted + JSON output for humans/CI
 ```
 
 ## Module Map
@@ -49,7 +49,9 @@ src/
   core/index.ts        <- Shared result computation (MCP + CLI)
   operations/index.ts  <- Analysis operation descriptors + typed input schemas
   operations/formatters.ts <- Result-object text formatters for CLI commands
-  mcp/index.ts         <- 17 MCP tools for LLM integration
+  parser/duplication.ts <- Function-body clone token extraction
+  duplication/index.ts <- Duplicate family detection + trace evidence
+  mcp/index.ts         <- 18 MCP tools for LLM integration
   mcp/hints.ts         <- Operation-keyed next-step hints for MCP tool responses
   impact/index.ts      <- Symbol-level impact analysis + rename planning
   search/index.ts      <- BM25 search engine
@@ -70,7 +72,7 @@ loadCodebaseGraph(rootDir)
   -> otherwise emits progress events through parse/build/analyze/cache
 
 parseCodebase(rootDir)
-  -> ParsedFile[] (with churn, complexity, test mapping)
+  -> ParsedFile[] (with churn, complexity, test mapping, symbol type facts, duplicate token facts)
 
 buildGraph(parsedFiles)
   -> BuiltGraph { graph: Graph, nodes: GraphNode[], edges: GraphEdge[] }
@@ -259,7 +261,7 @@ The most dangerous files have: high churn + high coupling + low coverage.
 
 # MCP Tools Reference
 
-17 tools available via MCP stdio.
+18 tools available via MCP stdio.
 
 ## 1. codebase_overview
 High-level summary. Input: `{ depth?: number }`. Returns: totalFiles, totalFunctions, modules, topDependedFiles, metrics, and analysis mode/call graph precision.
@@ -285,31 +287,34 @@ Unused exports. Input: `{ module?: string, limit?: number }`. Returns: files wit
 ## 8. find_opportunities
 Rank code quality and refactoring opportunities. Input: `{ limit?: number }`. Returns: ranked opportunities with priority, confidence, evidence, and suggested commands.
 
-## 9. get_groups
+## 9. find_duplicates
+Duplicate function families. Input: `{ mode?: "strict" | "mild" | "weak", minTokens?: number, skipLocal?: boolean, trace?: string }`. Returns: family IDs, members, token counts, similarity thresholds, and optional trace evidence.
+
+## 10. get_groups
 Top-level directory groups. Input: `{}`. Returns: groups with rank, files, loc, importance, coupling.
 
-## 10. symbol_context
+## 11. symbol_context
 Function/class/method context. Input: `{ name: string }`. Returns: callers, callees, metrics, additive typeFacts when known.
 
-## 11. search
+## 12. search
 Keyword/search shape facts (BM25). Input: `{ query: string, limit?: number }`. Returns: ranked files + symbols with additive typeFacts when known.
 
-## 12. detect_changes
+## 13. detect_changes
 Git diff analysis. Input: `{ scope?: "staged" | "unstaged" | "all" }`. Returns: changed files, affected files, risk metrics.
 
-## 13. impact_analysis
+## 14. impact_analysis
 Symbol-level blast radius. Input: `{ symbol: string }`. Returns: depth-grouped impact levels.
 
-## 14. rename_symbol
+## 15. rename_symbol
 Reference finder for rename planning. Input: `{ oldName: string, newName: string, dryRun?: boolean }`. Returns: references with confidence.
 
-## 15. get_processes
+## 16. get_processes
 Entry point execution flows. Input: `{ entryPoint?: string, limit?: number }`. Returns: processes with steps and depth.
 
-## 16. get_clusters
+## 17. get_clusters
 Community-detected file clusters. Input: `{ minFiles?: number }`. Returns: clusters with cohesion.
 
-## 17. check
+## 18. check
 Rules-engine gate. Input: `{}`. Returns: pass/warn/fail verdict, findings, config path, and summary counts.
 
 ## Tool Selection Guide
@@ -324,6 +329,7 @@ Rules-engine gate. Input: `{}`. Returns: pass/warn/fail verdict, findings, confi
 | Which files need tests? | find_hotspots (coverage) |
 | What should I improve first? | find_opportunities |
 | Find refactoring opportunities | find_opportunities |
+| Where is logic duplicated? | find_duplicates |
 | What can I safely delete? | find_dead_exports |
 | How are modules organized? | get_module_structure |
 | What's architecturally wrong? | analyze_forces |
@@ -339,7 +345,7 @@ Rules-engine gate. Input: `{}`. Returns: pass/warn/fail verdict, findings, confi
 
 # CLI Reference
 
-18 commands — 16 analysis commands (full parity with MCP tools), `check` for CI rules, and `init` for agent adoption.
+19 commands — 17 analysis commands (full parity with MCP tools), `check` for CI rules, and `init` for agent adoption.
 
 ## Commands
 
@@ -402,6 +408,12 @@ Find unused exports across the codebase.
 codebase-intelligence opportunities <path> [--limit <n>] [--json] [--force]
 ```
 Rank code quality and refactoring opportunities with evidence, confidence, and suggested commands.
+
+### duplicates
+```bash
+codebase-intelligence duplicates <path> [--mode <mode>] [--min-tokens <n>] [--skip-local] [--trace <id>] [--json] [--force]
+```
+Detect strict, renamed, and near-miss duplicate function families.
 
 ### groups
 ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 - [Architecture](docs/architecture.md): Pipeline, module map, data flow, design decisions
 - [Data Model](docs/data-model.md): All TypeScript interfaces with field descriptions
 - [Metrics](docs/metrics.md): Per-file and module metrics, force analysis, complexity scoring
-- [MCP Tools](docs/mcp-tools.md): 17 MCP tools — inputs, outputs, use cases, selection guide
+- [MCP Tools](docs/mcp-tools.md): 18 MCP tools — inputs, outputs, use cases, selection guide
 - [CLI Reference](docs/cli-reference.md): CLI commands, flags, output formats, examples
 
 ## Quick Start
@@ -17,7 +17,7 @@ MCP mode (AI agents):
 codebase-intelligence ./path/to/project
 ```
 
-CLI mode (humans/CI) — 18 commands (16 analysis with MCP parity + `check` + `init`):
+CLI mode (humans/CI) — 19 commands (17 analysis with MCP parity + `check` + `init`):
 ```bash
 codebase-intelligence overview ./src
 codebase-intelligence hotspots ./src --metric coupling
@@ -29,6 +29,7 @@ codebase-intelligence modules ./src
 codebase-intelligence forces ./src
 codebase-intelligence dead-exports ./src
 codebase-intelligence opportunities ./src --limit 10
+codebase-intelligence duplicates ./src --mode mild --min-tokens 30
 codebase-intelligence groups ./src
 codebase-intelligence symbol ./src parseCodebase
 codebase-intelligence impact ./src getUserById

--- a/roadmap.md
+++ b/roadmap.md
@@ -304,13 +304,18 @@ Capture resolved parameter and return types per symbol.
 
 Add deterministic clone detection on the existing parser path.
 
-**To do:**
+**Foundation slice:**
 
 - Implement `strict`, `mild`, and `weak` clone modes.
 - Emit clone families, not isolated pair findings.
 - Support `--min-tokens`, `--skip-local`, `--trace <id>`, and `--json`.
-- Feed step-similarity signals into Highways.
-- Defer semantic/shape-based duplication until the Type/Shape layer exists.
+- Add CH-P1-04 coverage for exact clones, renamed clones, near-miss clones, below-threshold noise, trace output, stable IDs/order, CLI/MCP parity, and local-only skipping.
+- Expose deterministic similarity scores for later Highways routing.
+
+**Remaining:**
+
+- Feed duplication similarity signals into Highways once Highways exists.
+- Add semantic/shape-based duplication on top of the Type/Shape layer.
 
 ### Dead Code Beyond Exports
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,6 +190,13 @@ interface OpportunitiesOptions extends CliCommandOptions {
   limit?: string;
 }
 
+interface DuplicationOptions extends CliCommandOptions {
+  mode?: string;
+  minTokens?: string;
+  skipLocal?: boolean;
+  trace?: string;
+}
+
 interface ProcessesOptions extends CliCommandOptions {
   entry?: string;
   limit?: string;
@@ -487,6 +494,36 @@ program
     }
 
     outputOperationText(operations.opportunities, result, input);
+  });
+
+// ── Subcommand: duplicates ─────────────────────────────────
+
+program
+  .command("duplicates")
+  .description("Detect duplicate function families (strict, mild, weak)")
+  .argument("<path>", "Path to TypeScript codebase")
+  .option("--mode <mode>", "Clone mode: strict, mild, or weak (default: mild)")
+  .option("--min-tokens <n>", "Minimum tokens to consider (default: 30)")
+  .option("--skip-local", "Ignore duplicate families confined to one file")
+  .option("--trace <id>", "Return token evidence for a duplicate family id")
+  .option("--json", "Output as JSON")
+  .option("--force", "Re-index even if HEAD unchanged")
+  .action((targetPath: string, options: DuplicationOptions) => {
+    const input = parseCliOperationInput(operations.duplication, {
+      mode: options.mode,
+      minTokens: optionalIntegerInput(options.minTokens),
+      skipLocal: options.skipLocal,
+      trace: options.trace,
+    });
+    const { graph } = loadGraph(targetPath, forceOption(options));
+    const result = runCliOperation(operations.duplication, graph, input);
+
+    if (options.json) {
+      outputJson(result);
+      return;
+    }
+
+    outputOperationText(operations.duplication, result, input);
   });
 
 // ── Subcommand: groups ─────────────────────────────────────

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,8 @@ import type { AnalysisMode, CallGraphPrecision, CodebaseGraph, SymbolTypeFacts }
 import { createSearchIndex, search, getSuggestions } from "../search/index.js";
 import type { SearchIndex } from "../search/index.js";
 import { impactAnalysis, renameSymbol } from "../impact/index.js";
+export { computeDuplication } from "../duplication/index.js";
+export type { DuplicationOptions, DuplicationResult } from "../duplication/index.js";
 
 // ── Path helpers ────────────────────────────────────────────
 

--- a/src/duplication/index.ts
+++ b/src/duplication/index.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import type { CodebaseGraph, DuplicationMode, SymbolDuplicationFacts } from "../types/index.js";
+
+export const DUPLICATION_MODES = ["strict", "mild", "weak"] as const;
+export const DEFAULT_DUPLICATION_MODE: DuplicationMode = "mild";
+export const DEFAULT_DUPLICATION_MIN_TOKENS = 30;
+
+const DUPLICATION_THRESHOLDS: Record<DuplicationMode, number> = {
+  strict: 1,
+  mild: 1,
+  weak: 0.72,
+};
+
+interface DuplicationCandidate {
+  key: string;
+  file: string;
+  symbol: string;
+  loc: number;
+  tokenCount: number;
+  tokens: string[];
+  hash: string;
+}
+
+export interface DuplicationOptions {
+  mode?: DuplicationMode;
+  minTokens?: number;
+  skipLocal?: boolean;
+  trace?: string;
+}
+
+export interface DuplicationMember {
+  file: string;
+  symbol: string;
+  loc: number;
+  tokenCount: number;
+  hash: string;
+}
+
+export interface DuplicationSimilarity {
+  threshold: number;
+  average: number;
+  minimum: number;
+}
+
+export interface DuplicationFamily {
+  id: string;
+  mode: DuplicationMode;
+  memberCount: number;
+  tokenCount: number;
+  similarity: DuplicationSimilarity;
+  members: DuplicationMember[];
+  evidence: string;
+}
+
+export interface DuplicationTraceMember {
+  file: string;
+  symbol: string;
+  tokens: string[];
+  truncated: boolean;
+}
+
+export interface DuplicationTracePair {
+  left: string;
+  right: string;
+  similarity: number;
+}
+
+export interface DuplicationTrace {
+  id: string;
+  found: boolean;
+  mode: DuplicationMode;
+  threshold: number;
+  members: DuplicationTraceMember[];
+  pairwise: DuplicationTracePair[];
+  reason?: string;
+}
+
+export interface DuplicationResult {
+  mode: DuplicationMode;
+  minTokens: number;
+  skipLocal: boolean;
+  threshold: number;
+  totalCandidates: number;
+  totalFamilies: number;
+  families: DuplicationFamily[];
+  trace?: DuplicationTrace;
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 10);
+}
+
+function memberKey(member: { file: string; symbol: string }): string {
+  return `${member.file}::${member.symbol}`;
+}
+
+function roundSimilarity(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function compareCandidate(left: DuplicationCandidate, right: DuplicationCandidate): number {
+  const byFile = left.file.localeCompare(right.file);
+  if (byFile !== 0) return byFile;
+  if (left.loc !== right.loc) return left.loc - right.loc;
+  return left.symbol.localeCompare(right.symbol);
+}
+
+function symbolDuplication(
+  duplication: SymbolDuplicationFacts | undefined,
+  mode: DuplicationMode,
+): { tokenCount: number; tokens: string[]; hash: string } | undefined {
+  if (!duplication) return undefined;
+  return {
+    tokenCount: duplication.tokenCount,
+    tokens: duplication.tokens[mode],
+    hash: duplication.hashes[mode],
+  };
+}
+
+function collectCandidates(graph: CodebaseGraph, mode: DuplicationMode, minTokens: number): DuplicationCandidate[] {
+  return graph.symbolNodes
+    .flatMap((symbol): DuplicationCandidate[] => {
+      if (symbol.type !== "function") return [];
+      const duplication = symbolDuplication(symbol.duplication, mode);
+      if (!duplication || duplication.tokenCount < minTokens) return [];
+      return [{
+        key: memberKey({ file: symbol.file, symbol: symbol.name }),
+        file: symbol.file,
+        symbol: symbol.name,
+        loc: symbol.loc,
+        tokenCount: duplication.tokenCount,
+        tokens: duplication.tokens,
+        hash: duplication.hash,
+      }];
+    })
+    .sort(compareCandidate);
+}
+
+function sequenceSimilarity(left: string[], right: string[]): number {
+  if (left.length === 0 || right.length === 0) return 0;
+  if (left.length === right.length && left.every((token, index) => token === right[index])) return 1;
+
+  const previous = new Array<number>(right.length + 1).fill(0);
+  const current = new Array<number>(right.length + 1).fill(0);
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      current[rightIndex] = left[leftIndex - 1] === right[rightIndex - 1]
+        ? previous[rightIndex - 1] + 1
+        : Math.max(previous[rightIndex], current[rightIndex - 1]);
+    }
+    for (let rightIndex = 0; rightIndex <= right.length; rightIndex += 1) {
+      previous[rightIndex] = current[rightIndex];
+      current[rightIndex] = 0;
+    }
+  }
+
+  return previous[right.length] / Math.max(left.length, right.length);
+}
+
+function tokenCountCanReachThreshold(
+  left: DuplicationCandidate,
+  right: DuplicationCandidate,
+  threshold: number,
+): boolean {
+  return Math.min(left.tokens.length, right.tokens.length) / Math.max(left.tokens.length, right.tokens.length) >= threshold;
+}
+
+function exactGroups(candidates: DuplicationCandidate[]): DuplicationCandidate[][] {
+  const byHash = new Map<string, DuplicationCandidate[]>();
+  for (const candidate of candidates) {
+    const existing = byHash.get(candidate.hash);
+    if (existing) existing.push(candidate);
+    else byHash.set(candidate.hash, [candidate]);
+  }
+  return [...byHash.values()].filter((group) => group.length > 1);
+}
+
+function weakGroups(candidates: DuplicationCandidate[], threshold: number): DuplicationCandidate[][] {
+  const groups: DuplicationCandidate[][] = [];
+  const assigned = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (assigned.has(candidate.key)) continue;
+    const group = [candidate];
+
+    for (const other of candidates) {
+      if (candidate.key === other.key || assigned.has(other.key)) continue;
+      const similarToAll = group.every((member) =>
+        tokenCountCanReachThreshold(member, other, threshold)
+        && sequenceSimilarity(member.tokens, other.tokens) >= threshold
+      );
+      if (similarToAll) group.push(other);
+    }
+
+    if (group.length > 1) {
+      for (const member of group) assigned.add(member.key);
+      groups.push(group);
+    }
+  }
+
+  return groups;
+}
+
+function isCrossFileGroup(group: DuplicationCandidate[]): boolean {
+  return new Set(group.map((candidate) => candidate.file)).size > 1;
+}
+
+function pairwiseSimilarities(group: DuplicationCandidate[]): DuplicationTracePair[] {
+  const pairs: DuplicationTracePair[] = [];
+  for (let leftIndex = 0; leftIndex < group.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < group.length; rightIndex += 1) {
+      const left = group[leftIndex];
+      const right = group[rightIndex];
+      pairs.push({
+        left: left.key,
+        right: right.key,
+        similarity: roundSimilarity(sequenceSimilarity(left.tokens, right.tokens)),
+      });
+    }
+  }
+  return pairs;
+}
+
+function summarizeSimilarity(threshold: number, pairs: DuplicationTracePair[]): DuplicationSimilarity {
+  if (pairs.length === 0) return { threshold, average: 1, minimum: 1 };
+  const scores = pairs.map((pair) => pair.similarity);
+  const sum = scores.reduce((total, score) => total + score, 0);
+  return {
+    threshold,
+    average: roundSimilarity(sum / scores.length),
+    minimum: Math.min(...scores),
+  };
+}
+
+function buildFamily(mode: DuplicationMode, threshold: number, group: DuplicationCandidate[]): DuplicationFamily {
+  const members = [...group]
+    .sort(compareCandidate)
+    .map((member) => ({
+      file: member.file,
+      symbol: member.symbol,
+      loc: member.loc,
+      tokenCount: member.tokenCount,
+      hash: member.hash,
+    }));
+  const seed = `${mode}:${members.map(memberKey).join("|")}:${members.map((member) => member.hash).join("|")}`;
+  const pairs = pairwiseSimilarities(group);
+  const tokenCount = Math.min(...members.map((member) => member.tokenCount));
+
+  return {
+    id: `dup-${mode}-${hashString(seed)}`,
+    mode,
+    memberCount: members.length,
+    tokenCount,
+    similarity: summarizeSimilarity(threshold, pairs),
+    members,
+    evidence: `${members.length} function-like symbols share at least ${tokenCount} normalized tokens`,
+  };
+}
+
+function compareFamily(left: DuplicationFamily, right: DuplicationFamily): number {
+  const leftFirst = left.members[0];
+  const rightFirst = right.members[0];
+  const byFile = leftFirst.file.localeCompare(rightFirst.file);
+  if (byFile !== 0) return byFile;
+  if (leftFirst.loc !== rightFirst.loc) return leftFirst.loc - rightFirst.loc;
+  return left.id.localeCompare(right.id);
+}
+
+function traceFamily(
+  id: string,
+  mode: DuplicationMode,
+  threshold: number,
+  family: DuplicationFamily | undefined,
+  candidatesByKey: Map<string, DuplicationCandidate>,
+): DuplicationTrace {
+  if (!family) {
+    return {
+      id,
+      found: false,
+      mode,
+      threshold,
+      members: [],
+      pairwise: [],
+      reason: "No duplicate family matched the current mode, minTokens, and skipLocal filters.",
+    };
+  }
+
+  const candidates = family.members
+    .map((member) => candidatesByKey.get(memberKey(member)))
+    .filter((candidate): candidate is DuplicationCandidate => candidate !== undefined);
+
+  return {
+    id,
+    found: true,
+    mode,
+    threshold,
+    members: candidates.map((candidate) => ({
+      file: candidate.file,
+      symbol: candidate.symbol,
+      tokens: candidate.tokens.slice(0, 120),
+      truncated: candidate.tokens.length > 120,
+    })),
+    pairwise: pairwiseSimilarities(candidates),
+  };
+}
+
+export function computeDuplication(graph: CodebaseGraph, options: DuplicationOptions = {}): DuplicationResult {
+  const mode = options.mode ?? DEFAULT_DUPLICATION_MODE;
+  const minTokens = options.minTokens ?? DEFAULT_DUPLICATION_MIN_TOKENS;
+  const skipLocal = options.skipLocal ?? false;
+  const threshold = DUPLICATION_THRESHOLDS[mode];
+  const candidates = collectCandidates(graph, mode, minTokens);
+  const groups = mode === "weak" ? weakGroups(candidates, threshold) : exactGroups(candidates);
+  const families = groups
+    .filter((group) => !skipLocal || isCrossFileGroup(group))
+    .map((group) => buildFamily(mode, threshold, group))
+    .sort(compareFamily);
+  const candidatesByKey = new Map(candidates.map((candidate) => [candidate.key, candidate]));
+  const tracedFamily = options.trace ? families.find((family) => family.id === options.trace) : undefined;
+
+  return {
+    mode,
+    minTokens,
+    skipLocal,
+    threshold,
+    totalCandidates: candidates.length,
+    totalFamilies: families.length,
+    families: options.trace ? families.filter((family) => family.id === options.trace) : families,
+    trace: options.trace ? traceFamily(options.trace, mode, threshold, tracedFamily, candidatesByKey) : undefined,
+  };
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -141,6 +141,7 @@ export function buildGraph(files: ParsedFile[]): BuiltGraph {
           complexity: symbol.complexity,
           isExported: symbol.isExported,
           typeFacts: symbol.typeFacts,
+          duplication: symbol.duplication,
         });
         if (!callGraphNodeIds.has(symbolId)) {
           callGraph.addNode(symbolId, { name: symbol.name, type: symbol.type, file: file.relativePath });

--- a/src/mcp/hints.ts
+++ b/src/mcp/hints.ts
@@ -42,6 +42,11 @@ const OPERATION_HINTS: Record<OperationName, string[]> = {
     "Use get_dependents for stabilize-hotspot or add-tests opportunities",
     "Use analyze_forces for extract-seam, move-file, and split-module opportunities",
   ],
+  duplication: [
+    "Use trace with a family id to inspect token evidence",
+    "Use file_context on duplicated members before refactoring",
+    "Use --skip-local when you only care about cross-file duplication",
+  ],
   groups: [
     "Use get_module_structure for detailed per-module breakdown",
     "Use find_hotspots with metric='coupling' to find cross-group coupling",

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -103,6 +103,7 @@ export function registerTools(server: McpServer, graph: CodebaseGraph): void {
   registerOperationTool(server, graph, operations.forces);
   registerOperationTool(server, graph, operations.deadExports);
   registerOperationTool(server, graph, operations.opportunities);
+  registerOperationTool(server, graph, operations.duplication);
   registerOperationTool(server, graph, operations.groups, {
     successPayload: (computed) => computed.groups.length === 0 ? { message: "No groups found." } : computed,
   });

--- a/src/operations/formatters.ts
+++ b/src/operations/formatters.ts
@@ -5,6 +5,7 @@ import type {
   DeadExportsResult,
   DependentsError,
   DependentsResult,
+  DuplicationResult,
   FileContextError,
   FileContextResult,
   ForcesResult,
@@ -407,6 +408,51 @@ export function formatOpportunitiesText(result: OpportunitiesResult): string {
       `  Evidence:   ${opportunity.evidence.join("; ")}`,
       `  Next:       ${opportunity.suggestedCommands[0] ?? "Review target manually"}`,
     );
+  }
+
+  return text(lines);
+}
+
+/**
+ * Format a duplication operation result for human CLI output.
+ */
+export function formatDuplicationText(result: DuplicationResult): string {
+  const lines = [
+    `Duplicate Families: ${result.mode}`,
+    "─".repeat(28 + result.mode.length),
+    `Threshold: ${result.threshold}`,
+    `Min tokens: ${result.minTokens}`,
+    `Candidates: ${result.totalCandidates}`,
+    `Families: ${result.totalFamilies}`,
+  ];
+
+  if (result.skipLocal) lines.push("Local-only families: skipped");
+
+  if (result.families.length === 0) {
+    lines.push("", result.trace ? `Trace ${result.trace.id}: ${result.trace.reason ?? "not found"}` : "No duplicate families found.");
+    return text(lines);
+  }
+
+  for (const family of result.families) {
+    lines.push(
+      "",
+      `${family.id} (${family.memberCount} members, ${family.tokenCount} tokens, similarity ${family.similarity.minimum}-${family.similarity.average})`,
+      `  ${family.evidence}`,
+      ...family.members.map((member) => `  - ${member.file}::${member.symbol} (${member.loc} LOC)`),
+    );
+  }
+
+  if (result.trace?.found) {
+    lines.push("", `Trace: ${result.trace.id}`);
+    for (const member of result.trace.members) {
+      lines.push(`  ${member.file}::${member.symbol}`);
+      lines.push(`    ${member.tokens.join(" ")}`);
+      if (member.truncated) lines.push("    ...");
+    }
+    if (result.trace.pairwise.length > 0) {
+      lines.push("  Pairwise:");
+      lines.push(...result.trace.pairwise.map((pair) => `    ${pair.left} ↔ ${pair.right}: ${pair.similarity}`));
+    }
   }
 
   return text(lines);

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -6,6 +6,7 @@ import {
   computeClusters,
   computeDeadExports,
   computeDependents,
+  computeDuplication,
   computeFileContext,
   computeForces,
   computeGroups,
@@ -19,12 +20,14 @@ import {
   impactAnalysis,
   renameSymbol,
 } from "../core/index.js";
+import { DUPLICATION_MODES } from "../duplication/index.js";
 import type { CodebaseGraph } from "../types/index.js";
 import {
   formatChangesText,
   formatClustersText,
   formatDeadExportsText,
   formatDependentsText,
+  formatDuplicationText,
   formatFileContextText,
   formatForcesText,
   formatGroupsText,
@@ -48,6 +51,7 @@ export const operationNames = [
   "forces",
   "deadExports",
   "opportunities",
+  "duplication",
   "groups",
   "symbolContext",
   "search",
@@ -116,6 +120,13 @@ const opportunitiesInputShape = {
   limit: z.number().int().positive().optional().describe("Max opportunities (default: 20)"),
 } satisfies z.ZodRawShape;
 const opportunitiesInputSchema = z.object(opportunitiesInputShape).strict();
+const duplicationInputShape = {
+  mode: z.enum(DUPLICATION_MODES).optional().describe("Clone mode: strict, mild, or weak (default: mild)"),
+  minTokens: z.number().int().positive().optional().describe("Minimum function body tokens to consider (default: 30)"),
+  skipLocal: z.boolean().optional().describe("Ignore duplicate families confined to one file"),
+  trace: z.string().min(1).optional().describe("Return token evidence for a duplicate family id"),
+} satisfies z.ZodRawShape;
+const duplicationInputSchema = z.object(duplicationInputShape).strict();
 const emptyInputShape = {} satisfies z.ZodRawShape;
 const emptyInputSchema = z.object(emptyInputShape).strict();
 const symbolContextInputShape = {
@@ -159,6 +170,7 @@ type ModuleStructureInput = z.infer<typeof moduleStructureInputSchema>;
 type ForcesInput = z.infer<typeof forcesInputSchema>;
 type DeadExportsInput = z.infer<typeof deadExportsInputSchema>;
 type OpportunitiesInput = z.infer<typeof opportunitiesInputSchema>;
+type DuplicationInput = z.infer<typeof duplicationInputSchema>;
 type EmptyInput = z.infer<typeof emptyInputSchema>;
 type SymbolContextInput = z.infer<typeof symbolContextInputSchema>;
 type SearchInput = z.infer<typeof searchInputSchema>;
@@ -250,6 +262,16 @@ export const operations = {
     run: (graph: CodebaseGraph, input: OpportunitiesInput) => computeOpportunities(graph, input.limit),
     formatText: formatOpportunitiesText,
   } satisfies Operation<OpportunitiesInput, ReturnType<typeof computeOpportunities>>,
+  duplication: {
+    name: "duplication",
+    cliCommand: "duplicates",
+    mcpTool: "find_duplicates",
+    description: "Detect duplicate function families with strict, mild, or weak clone modes. Use when: finding copy-paste logic, drift between similar functions, or refactor candidates. Not for: unused code (use find_dead_exports) or module-level cohesion (use analyze_forces)",
+    inputShape: duplicationInputShape,
+    inputSchema: duplicationInputSchema,
+    run: (graph: CodebaseGraph, input: DuplicationInput) => computeDuplication(graph, input),
+    formatText: formatDuplicationText,
+  } satisfies Operation<DuplicationInput, ReturnType<typeof computeDuplication>>,
   groups: {
     name: "groups",
     cliCommand: "groups",

--- a/src/parser/duplication.ts
+++ b/src/parser/duplication.ts
@@ -1,0 +1,101 @@
+import { createHash } from "node:crypto";
+import ts from "typescript";
+import type { DuplicationMode, SymbolDuplicationFacts } from "../types/index.js";
+
+const modes: DuplicationMode[] = ["strict", "mild", "weak"];
+
+type RawCloneTokenKind = "identifier" | "literal" | "operator" | "syntax";
+
+interface RawCloneToken {
+  kind: RawCloneTokenKind;
+  text: string;
+}
+
+function hashTokens(tokens: string[]): string {
+  return createHash("sha256").update(tokens.join("\0")).digest("hex").slice(0, 16);
+}
+
+function cloneScope(node: ts.Declaration): ts.Node | undefined {
+  if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node)) {
+    return node.body;
+  }
+  if (!ts.isVariableDeclaration(node)) return undefined;
+
+  const initializer = node.initializer;
+  if (!initializer || (!ts.isArrowFunction(initializer) && !ts.isFunctionExpression(initializer))) return undefined;
+  return initializer.body;
+}
+
+function normalizeToken(mode: DuplicationMode, token: RawCloneToken): string {
+  if (mode === "strict") return token.text;
+  if (token.kind === "identifier") return mode === "mild" ? "$id" : "$atom";
+  if (token.kind === "literal") return mode === "mild" ? "$literal" : "$atom";
+  if (mode === "weak" && token.kind === "operator") return "$operator";
+  return token.text;
+}
+
+function syntaxName(kind: ts.SyntaxKind): string {
+  return ts.SyntaxKind[kind];
+}
+
+function nodeToken(node: ts.Node, sourceFile: ts.SourceFile): RawCloneToken {
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) {
+    return { kind: "identifier", text: node.text };
+  }
+  if (
+    ts.isStringLiteralLike(node)
+    || ts.isNumericLiteral(node)
+    || ts.isRegularExpressionLiteral(node)
+    || ts.isTemplateHead(node)
+    || ts.isTemplateMiddle(node)
+    || ts.isTemplateTail(node)
+  ) {
+    return { kind: "literal", text: node.getText(sourceFile) };
+  }
+  return { kind: "syntax", text: syntaxName(node.kind) };
+}
+
+function pushOperatorToken(tokens: RawCloneToken[], kind: ts.SyntaxKind): void {
+  tokens.push({ kind: "operator", text: syntaxName(kind) });
+}
+
+function collectTokens(node: ts.Node, sourceFile: ts.SourceFile, tokens: RawCloneToken[]): void {
+  tokens.push(nodeToken(node, sourceFile));
+
+  if (ts.isBinaryExpression(node)) {
+    pushOperatorToken(tokens, node.operatorToken.kind);
+  } else if (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) {
+    pushOperatorToken(tokens, node.operator);
+  } else if (ts.isVariableDeclarationList(node)) {
+    tokens.push({ kind: "syntax", text: node.flags & ts.NodeFlags.Const ? "const" : "let" });
+  }
+
+  ts.forEachChild(node, (child) => {
+    collectTokens(child, sourceFile, tokens);
+  });
+}
+
+export function extractDuplicationFacts(
+  node: ts.Declaration,
+  sourceFile: ts.SourceFile,
+): SymbolDuplicationFacts | undefined {
+  const scope = cloneScope(node);
+  if (!scope) return undefined;
+
+  const rawTokens: RawCloneToken[] = [];
+  collectTokens(scope, sourceFile, rawTokens);
+  if (rawTokens.length === 0) return undefined;
+
+  const tokens: Record<DuplicationMode, string[]> = { strict: [], mild: [], weak: [] };
+  const hashes: Record<DuplicationMode, string> = { strict: "", mild: "", weak: "" };
+  for (const mode of modes) {
+    tokens[mode] = rawTokens.map((token) => normalizeToken(mode, token));
+    hashes[mode] = hashTokens(tokens[mode]);
+  }
+
+  return {
+    tokenCount: tokens.strict.length,
+    tokens,
+    hashes,
+  };
+}

--- a/src/parser/symbols.ts
+++ b/src/parser/symbols.ts
@@ -5,6 +5,7 @@ import {
   declarationTypeFactsFromSyntax,
   nodeLocation,
 } from "./type-facts.js";
+import { extractDuplicationFacts } from "./duplication.js";
 
 function parsedSymbol(
   name: string,
@@ -27,6 +28,7 @@ function parsedSymbol(
     complexity: computeComplexity(node),
     isExported,
     typeFacts,
+    duplication: extractDuplicationFacts(node, sourceFile),
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,14 @@ export interface SymbolTypeFacts {
   confidence: "resolved" | "syntax";
 }
 
+export type DuplicationMode = "strict" | "mild" | "weak";
+
+export interface SymbolDuplicationFacts {
+  tokenCount: number;
+  tokens: Record<DuplicationMode, string[]>;
+  hashes: Record<DuplicationMode, string>;
+}
+
 export interface ParsedExport {
   name: string;
   type: "function" | "class" | "variable" | "type" | "interface" | "enum";
@@ -45,6 +53,7 @@ export interface ParsedExport {
   isDefault: boolean;
   complexity: number;
   typeFacts?: SymbolTypeFacts;
+  duplication?: SymbolDuplicationFacts;
 }
 
 export interface ParsedSymbol extends ParsedExport {
@@ -104,6 +113,7 @@ export interface SymbolNode {
   complexity: number;
   isExported?: boolean;
   typeFacts?: SymbolTypeFacts;
+  duplication?: SymbolDuplicationFacts;
 }
 
 export interface SymbolMetrics {

--- a/tests/fixture-codebase/src/duplication/exact-a.ts
+++ b/tests/fixture-codebase/src/duplication/exact-a.ts
@@ -1,0 +1,7 @@
+export function normalizeEmail(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed.includes("@")) {
+    return `${trimmed}@example.com`;
+  }
+  return trimmed;
+}

--- a/tests/fixture-codebase/src/duplication/exact-b.ts
+++ b/tests/fixture-codebase/src/duplication/exact-b.ts
@@ -1,0 +1,7 @@
+export function formatAccountEmail(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed.includes("@")) {
+    return `${trimmed}@example.com`;
+  }
+  return trimmed;
+}

--- a/tests/fixture-codebase/src/duplication/local-only.ts
+++ b/tests/fixture-codebase/src/duplication/local-only.ts
@@ -1,0 +1,11 @@
+function localSortOne(items: string[]): string[] {
+  const copy = [...items];
+  copy.sort();
+  return copy;
+}
+
+function localSortTwo(items: string[]): string[] {
+  const copy = [...items];
+  copy.sort();
+  return copy;
+}

--- a/tests/fixture-codebase/src/duplication/near-miss.ts
+++ b/tests/fixture-codebase/src/duplication/near-miss.ts
@@ -1,0 +1,7 @@
+export function prepareInviteEmail(raw: string): string {
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized.includes("@")) {
+    return `${normalized}@example.com`;
+  }
+  return normalized || "unknown@example.com";
+}

--- a/tests/fixture-codebase/src/duplication/noise.ts
+++ b/tests/fixture-codebase/src/duplication/noise.ts
@@ -1,0 +1,3 @@
+export function tinyNoise(flag: boolean): boolean {
+  return !flag;
+}

--- a/tests/fixture-codebase/src/duplication/renamed.ts
+++ b/tests/fixture-codebase/src/duplication/renamed.ts
@@ -1,0 +1,7 @@
+export function sanitizeContactEmail(value: string): string {
+  const clean = value.trim().toLowerCase();
+  if (!clean.includes("@")) {
+    return `${clean}@example.com`;
+  }
+  return clean;
+}

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -4,6 +4,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getFixturePipeline } from "./helpers/pipeline.js";
 import { registerTools } from "../src/mcp/index.js";
+import { operationList } from "../src/operations/index.js";
 import { setGraph, setIndexedHead } from "../src/server/graph-store.js";
 import type { CodebaseGraph } from "../src/types/index.js";
 
@@ -482,8 +483,9 @@ describe("MCP Resources", () => {
     expect(setup).toHaveProperty("project", "codebase-intelligence");
     expect(setup).toHaveProperty("indexedHead", "abc123-test");
     expect(setup).toHaveProperty("availableTools");
-    expect((setup.availableTools as string[]).length).toBe(17);
+    expect((setup.availableTools as string[]).length).toBe(operationList.length + 1);
     expect(setup.availableTools as string[]).toContain("find_opportunities");
+    expect(setup.availableTools as string[]).toContain("find_duplicates");
     expect(setup.availableTools as string[]).toContain("check");
   });
 });

--- a/tests/operation-registry.e2e.test.ts
+++ b/tests/operation-registry.e2e.test.ts
@@ -72,6 +72,37 @@ function withoutCache(payload: Record<string, unknown>): Record<string, unknown>
   return normalized;
 }
 
+function recordArray(value: unknown, label: string): Record<string, unknown>[] {
+  expect(Array.isArray(value)).toBe(true);
+  if (!Array.isArray(value)) throw new Error(`Expected ${label} array`);
+  return value.filter(isRecord);
+}
+
+function familyMembers(family: Record<string, unknown>): string[] {
+  return recordArray(family.members, "members")
+    .map((member) => {
+      if (typeof member.file !== "string" || typeof member.symbol !== "string") {
+        throw new Error("Expected duplicate member file and symbol strings");
+      }
+      return `${member.file}::${member.symbol}`;
+    })
+    .sort();
+}
+
+function findFamily(payload: Record<string, unknown>, expectedMembers: string[]): Record<string, unknown> {
+  const sortedExpected = [...expectedMembers].sort();
+  const match = recordArray(payload.families, "families").find((family) => {
+    const members = familyMembers(family);
+    return sortedExpected.every((member) => members.includes(member));
+  });
+  if (!match) throw new Error(`Expected duplicate family containing ${sortedExpected.join(", ")}`);
+  return match;
+}
+
+function familyIds(payload: Record<string, unknown>): unknown[] {
+  return recordArray(payload.families, "families").map((family) => family.id);
+}
+
 async function expectMcpMatchesRegistry<TInput extends object, TResult>(
   operation: Operation<TInput, TResult>,
   input: TInput,
@@ -239,6 +270,14 @@ describe("operation registry chained parity", () => {
       {},
       cachedRun,
     );
+    expectCliMatchesRegistry(
+      operations.duplication,
+      { mode: "mild", minTokens: 8, skipLocal: false },
+      ["duplicates", getFixtureSrcPath(), "--mode", "mild", "--min-tokens", "8"],
+      codebaseGraph,
+      {},
+      cachedRun,
+    );
     expectCliMatchesRegistry(operations.groups, {}, ["groups", getFixtureSrcPath()], codebaseGraph, {}, cachedRun);
     expectCliMatchesRegistry(
       operations.symbolContext,
@@ -349,6 +388,14 @@ describe("operation registry chained parity", () => {
       operations.opportunities,
       { limit: 5 },
       ["opportunities", getFixtureSrcPath(), "--limit", "5"],
+      codebaseGraph,
+      {},
+      cachedRun,
+    );
+    expectCliTextMatchesFormatter(
+      operations.duplication,
+      { mode: "mild", minTokens: 8, skipLocal: false },
+      ["duplicates", getFixtureSrcPath(), "--mode", "mild", "--min-tokens", "8"],
       codebaseGraph,
       {},
       cachedRun,
@@ -503,6 +550,66 @@ describe("operation registry chained parity", () => {
     expect(withoutNextSteps(mcpSymbol)).toEqual(withoutCache(cliSymbol));
   });
 
+  it("CH-P1-04: duplicate families support strict/mild/weak modes, trace, and local skipping", async () => {
+    runCliJson(["overview", getFixtureSrcPath()]);
+    const cachedRun = { force: false };
+    const exactMembers = [
+      "duplication/exact-a.ts::normalizeEmail",
+      "duplication/exact-b.ts::formatAccountEmail",
+    ];
+    const renamedMember = "duplication/renamed.ts::sanitizeContactEmail";
+    const nearMissMember = "duplication/near-miss.ts::prepareInviteEmail";
+    const localMembers = [
+      "duplication/local-only.ts::localSortOne",
+      "duplication/local-only.ts::localSortTwo",
+    ];
+
+    const strictPayload = runCliJson(["duplicates", getFixtureSrcPath(), "--mode", "strict", "--min-tokens", "8"], cachedRun);
+    expect(strictPayload).toMatchObject({ mode: "strict", threshold: 1, minTokens: 8, skipLocal: false });
+    const strictFamily = findFamily(strictPayload, exactMembers);
+    expect(strictFamily.id).toMatch(/^dup-strict-[a-f0-9]{10}$/);
+    expect(familyMembers(strictFamily)).toEqual(exactMembers);
+    const strictAgain = runCliJson(["duplicates", getFixtureSrcPath(), "--mode", "strict", "--min-tokens", "8"], cachedRun);
+    expect(familyIds(strictAgain)).toEqual(familyIds(strictPayload));
+
+    const mildPayload = runCliJson(["duplicates", getFixtureSrcPath(), "--mode", "mild", "--min-tokens", "8"], cachedRun);
+    expect(mildPayload).toMatchObject({ mode: "mild", threshold: 1, minTokens: 8 });
+    const mildFamily = findFamily(mildPayload, [...exactMembers, renamedMember]);
+    expect(familyMembers(mildFamily)).toContain(renamedMember);
+    expect(String(mildFamily.id)).toMatch(/^dup-mild-[a-f0-9]{10}$/);
+
+    const weakPayload = runCliJson(["duplicates", getFixtureSrcPath(), "--mode", "weak", "--min-tokens", "8"], cachedRun);
+    expect(weakPayload).toMatchObject({ mode: "weak", threshold: 0.72, minTokens: 8 });
+    const weakFamily = findFamily(weakPayload, [...exactMembers, renamedMember, nearMissMember]);
+    expect(familyMembers(weakFamily)).not.toContain("duplication/noise.ts::tinyNoise");
+
+    const skipLocalPayload = runCliJson(
+      ["duplicates", getFixtureSrcPath(), "--mode", "mild", "--min-tokens", "8", "--skip-local"],
+      cachedRun,
+    );
+    const skippedMembers = recordArray(skipLocalPayload.families, "families").flatMap(familyMembers);
+    expect(skippedMembers).not.toContain(localMembers[0]);
+    expect(skippedMembers).not.toContain(localMembers[1]);
+
+    const traceId = String(mildFamily.id);
+    const tracePayload = runCliJson(
+      ["duplicates", getFixtureSrcPath(), "--mode", "mild", "--min-tokens", "8", "--trace", traceId],
+      cachedRun,
+    );
+    expect(tracePayload.trace).toMatchObject({ id: traceId, found: true, mode: "mild", threshold: 1 });
+    const trace = tracePayload.trace;
+    expect(isRecord(trace)).toBe(true);
+    if (!isRecord(trace)) throw new Error("Expected trace object");
+    expect(recordArray(trace.members, "trace.members")).toHaveLength(familyMembers(mildFamily).length);
+    expect(recordArray(trace.pairwise, "trace.pairwise").length).toBeGreaterThan(0);
+
+    const mcp = await createFixtureMcp();
+    const mcpWeak = await mcp.callTool("find_duplicates", { mode: "weak", minTokens: 8 });
+    expect(withoutNextSteps(mcpWeak)).toEqual(withoutCache(weakPayload));
+    const mcpTrace = await mcp.callTool("find_duplicates", { mode: "mild", minTokens: 8, trace: traceId });
+    expect(withoutNextSteps(mcpTrace)).toEqual(withoutCache(tracePayload));
+  });
+
   it("CH-P1-01: registry-adapted MCP tools match descriptor runs for every operation", async () => {
     const { codebaseGraph } = getFixturePipeline();
     const mcp = await createFixtureMcp();
@@ -548,6 +655,13 @@ describe("operation registry chained parity", () => {
       operations.opportunities,
       { limit: 5 },
       { limit: 5 },
+      codebaseGraph,
+      mcp,
+    );
+    await expectMcpMatchesRegistry(
+      operations.duplication,
+      { mode: "mild", minTokens: 8, skipLocal: false },
+      { mode: "mild", minTokens: 8, skipLocal: false },
       codebaseGraph,
       mcp,
     );

--- a/tests/operation-registry.test.ts
+++ b/tests/operation-registry.test.ts
@@ -30,6 +30,7 @@ const expectedOperations: Array<{
   { name: "forces", cliCommand: "forces", mcpTool: "analyze_forces", inputKeys: ["cohesionThreshold", "tensionThreshold", "escapeThreshold"], sampleInput: { cohesionThreshold: 0.6 } },
   { name: "deadExports", cliCommand: "dead-exports", mcpTool: "find_dead_exports", inputKeys: ["module", "limit"], sampleInput: { limit: 5 } },
   { name: "opportunities", cliCommand: "opportunities", mcpTool: "find_opportunities", inputKeys: ["limit"], sampleInput: { limit: 5 } },
+  { name: "duplication", cliCommand: "duplicates", mcpTool: "find_duplicates", inputKeys: ["mode", "minTokens", "skipLocal", "trace"], sampleInput: { mode: "mild", minTokens: 30, skipLocal: true } },
   { name: "groups", cliCommand: "groups", mcpTool: "get_groups", inputKeys: [], sampleInput: {} },
   { name: "symbolContext", cliCommand: "symbol", mcpTool: "symbol_context", inputKeys: ["name"], sampleInput: { name: "getUserById" } },
   { name: "search", cliCommand: "search", mcpTool: "search", inputKeys: ["query", "limit"], sampleInput: { query: "auth", limit: 5 } },

--- a/tools/verify-cli-real-codebases.mjs
+++ b/tools/verify-cli-real-codebases.mjs
@@ -380,6 +380,14 @@ for (const inputTarget of targets) {
     });
   }
 
+  record(`${target.name}: duplicates`, () => {
+    const result = json(["duplicates", target.path, "--mode", "weak", "--min-tokens", "30"]);
+    if (result.mode !== "weak" || typeof result.threshold !== "number" || !Array.isArray(result.families)) {
+      throw new Error("bad duplicates payload");
+    }
+    return `${result.totalFamilies} families`;
+  });
+
   record(`${target.name}: check`, () => {
     const output = run(["check", target.path, "--format", "json"], [0, 1]);
     const result = JSON.parse(output.stdout);


### PR DESCRIPTION
## Summary
- add deterministic duplicate function family detection with strict, mild, and weak modes
- expose `duplicates` CLI and `find_duplicates` MCP operation through the shared registry
- add CH-P1-04 chained CLI/MCP coverage, fixture clone families, docs, roadmap sync, and real-repo verifier coverage

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (456/456)
- `pnpm verify:cli-real` (pass=59 fail=0)
- `git diff --check`
- code-review artifact: `/tmp/code-review-duplication-families.json` (CLEAN, 89/89 hunks, 7/7 rules)
